### PR TITLE
Upgrade Smithy to 1.33.0

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
     version = "0.1.0"
 }
 
-extra["smithyVersion"] = "1.28.0"
+extra["smithyVersion"] = "1.33.0"
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -379,8 +379,8 @@ public class HttpProtocolTestGenerator {
                     case "application/xml":
                         if (body.get().length() > 0) {
                             writer
-                                    .write("expect($T.parse(request.body.read)).to "
-                                                    + "match_xml_node($T.parse('$L'))",
+                                    .write("expect($1T.parse(request.body.read)).to "
+                                                    + "match_xml_node($1T.parse('$2L'))",
                                             Hearth.XML, body.get())
                                     .addUseImports(RubyDependency.HEARTH_XML_MATCHER);
                         } else {


### PR DESCRIPTION
Upgrading the Smithy dependency to 1.33.0

Also made a minor fix so that we can successfully build this dependency with v4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
