### PR TITLE
Service Integrations (specify integrations in smithy-build.json)

### DIFF
--- a/codegen/smithy-ruby-codegen-test-utils/src/main/java/software/amazon/smithy/ruby/codegen/integrations/PluginTestIntegration.java
+++ b/codegen/smithy-ruby-codegen-test-utils/src/main/java/software/amazon/smithy/ruby/codegen/integrations/PluginTestIntegration.java
@@ -16,23 +16,20 @@
 package software.amazon.smithy.ruby.codegen.integrations;
 
 import java.util.List;
-import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
-import software.amazon.smithy.ruby.codegen.RubyIntegration;
 import software.amazon.smithy.ruby.codegen.RubyRuntimePlugin;
+import software.amazon.smithy.ruby.codegen.RubyServiceIntegration;
 import software.amazon.smithy.ruby.codegen.config.ClientConfig;
 import software.amazon.smithy.ruby.codegen.middleware.Middleware;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareStackStep;
 
-public class WhiteLabelTestIntegration implements RubyIntegration {
+public class PluginTestIntegration extends RubyServiceIntegration {
 
     @Override
-    public boolean includeFor(ServiceShape service, Model model) {
-        return service.toShapeId().getName().equals("WhiteLabel");
+    public String name() {
+        return "plugin-test";
     }
-
 
     @Override
     public List<RubyRuntimePlugin> getRuntimePlugins(GenerationContext context) {

--- a/codegen/smithy-ruby-codegen-test-utils/src/main/resources/META-INF/services/software.amazon.smithy.ruby.codegen.RubyIntegration
+++ b/codegen/smithy-ruby-codegen-test-utils/src/main/resources/META-INF/services/software.amazon.smithy.ruby.codegen.RubyIntegration
@@ -1,1 +1,1 @@
-software.amazon.smithy.ruby.codegen.integrations.WhiteLabelTestIntegration
+software.amazon.smithy.ruby.codegen.integrations.PluginTestIntegration

--- a/codegen/smithy-ruby-codegen-test/smithy-build.json
+++ b/codegen/smithy-ruby-codegen-test/smithy-build.json
@@ -30,6 +30,7 @@
       "plugins": {
         "ruby-codegen": {
           "service": "smithy.ruby.tests#WhiteLabel",
+          "integrations": ["plugin-test"],
           "module": "WhiteLabel",
           "gemspec": {
             "gemName": "white_label",

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
@@ -75,7 +75,8 @@ public class DirectedRubyCodegen
         Model model = directive.model();
         List<RubyIntegration> integrations = directive.integrations().stream()
                 .filter((integration) -> integration
-                        .includeFor(service, model))
+                        .includeFor(service, model)
+                        || directive.settings().getIntegrations().contains(integration.name()))
                 .collect(Collectors.toList());
 
         Map<ShapeId, ProtocolGenerator> supportedProtocols = ProtocolGenerator

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyServiceIntegration.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyServiceIntegration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * A RubyIntegration that should be applied to services by specifying `integrations`
+ * in the smithy-build.json for the applicable services.
+ */
+@SmithyUnstableApi
+public abstract class RubyServiceIntegration implements  RubyIntegration {
+    public boolean includeFor(ServiceShape service, Model model) {
+        return false;
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Allows integrations to be specified in the smithy-build.json using a new `integration` config.  This allows service specific integrations - but doesn't limit the flexibility of the `includeFor` for plugins that need to inspect the model (eg, integrations that check for presence of a certain trait on the model). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
