### PR TITLE
Codegen Output Demo - Config Constraints

### DIFF
--- a/codegen/projections/white_label/lib/white_label/config.rb
+++ b/codegen/projections/white_label/lib/white_label/config.rb
@@ -128,6 +128,13 @@ module WhiteLabel
       Hearth::Validator.validate_types!(validate_input, TrueClass, FalseClass, context: 'config[:validate_input]')
     end
 
+    def validate_range!
+      Hearth::Validator.validate_range(
+        request_min_compression_size_bytes,
+        { :min_value => 0, :max_value => 10485760 },
+        context: 'config[:request_min_compression_size_bytes]')
+    end
+
     def self.defaults
       @defaults ||= {
         disable_host_prefix: [false],

--- a/hearth/lib/hearth/validator.rb
+++ b/hearth/lib/hearth/validator.rb
@@ -41,5 +41,20 @@ module Hearth
       raise ArgumentError,
             "Unexpected members: [#{unknown.join(', ')}]"
     end
+
+    # draft of what validate_range *could* look like
+    # valid_range param consists of min and max keys
+    def self.validate_range(value, valid_range, context:)
+      # need to validate the valid_range object before proceeding
+      # does it make sense us to use existing method - validate_type!
+      valid_range.each { |context, value| self.validate_type!(value, Integer, context: context) }
+
+      return if value.between?(valid_range[:min], valid_range[:max])
+
+      raise ArgumentError,
+            "Expected #{context} to be between " \
+            "#{minimum} to #{maximum}, got #{value}."
+    end
+
   end
 end


### PR DESCRIPTION
*Description of changes:*
Before I dive into the design/implementation work, I wanted to visualize what the end result _could_ look like in Hearth and the `config.rb` file in the projected service. 
In this possible implementation, I'm thinking of adding a `validate_range` method to the Hearth's `Validator` module

Please ignore the inconsistency of naming as this is just a rough draft.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
