### PR TITLE
Add support for a defaultLiteral to client config

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
@@ -135,10 +135,16 @@ public class ConfigGenerator extends RubyGeneratorBase {
                 .openBlock("@defaults ||= {");
 
         clientConfigList.forEach(clientConfig -> {
-            String defaults = clientConfig.getDefaults().getProviders().stream()
-                    .map((p) -> p.providerFragment().render(context))
-                    .collect(Collectors.joining(","));
-            writer.write("$L: [$L],", clientConfig.getName(), defaults);
+            if (clientConfig.getDefaults() == null) {
+                if (clientConfig.getDefaultLiteral() != null) {
+                    writer.write("$L: $L,", clientConfig.getName(), clientConfig.getDefaultLiteral());
+                }
+            } else {
+                String defaults = clientConfig.getDefaults().getProviders().stream()
+                        .map((p) -> p.providerFragment().render(context))
+                        .collect(Collectors.joining(","));
+                writer.write("$L: [$L],", clientConfig.getName(), defaults);
+            }
         });
 
         writer


### PR DESCRIPTION

*Description of changes:*
Sometimes we need to provide a literal (eg a constant, such as the `AWS::SDK::Core::CREDENTIAL_PROVIDER_CHAIN`) as the default. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
