### PR TITLE
Refactor ClientConfig defaults

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ClientFragment.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ClientFragment.java
@@ -40,6 +40,10 @@ public class ClientFragment {
         this.render = builder.render;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     /**
      * @return set of client config to apply to support this fragment.
      */
@@ -80,7 +84,6 @@ public class ClientFragment {
         };
 
         /**
-         *
          * @param config config to be added to support this fragment.
          * @return this builder.
          */

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.ruby.codegen.config;
 
 import java.util.Objects;
 import java.util.Set;
+import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -29,11 +30,8 @@ public class ClientConfig {
     private final String name;
     private final String type;
     private final String documentation;
-    private final String documentationDefaultValue;
     private final String documentationType;
-    private final ConfigProviderChain defaults;
-
-    private final String defaultLiteral;
+    private final ConfigDefaults defaults;
     private final boolean allowOperationOverride;
 
     /**
@@ -43,11 +41,20 @@ public class ClientConfig {
         this.name = builder.name;
         this.type = builder.type;
         this.documentation = builder.documentation;
-        this.documentationDefaultValue = builder.documentationDefaultValue;
         this.documentationType = builder.documentationType;
-        this.defaults = builder.defaults;
-        this.defaultLiteral = builder.defaultLiteral;
+        if (builder.defaults != null) {
+            this.defaults = builder.defaults;
+        } else {
+            this.defaults = new DefaultLiteral("[]");
+        }
+        if (builder.documentationDefaultValue != null) {
+            this.defaults.setDocumentationDefault(builder.documentationDefaultValue);
+        }
         this.allowOperationOverride = builder.allowOperationOverride;
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -79,13 +86,7 @@ public class ClientConfig {
      * @return Documented default value.
      */
     public String getDocumentationDefaultValue() {
-        if (documentationDefaultValue != null) {
-            return documentationDefaultValue;
-        }
-        if (defaults != null) {
-            return defaults.getDocumentationDefault().orElse("");
-        }
-        return "";
+        return defaults.getDocumentationDefault().orElse("");
     }
 
     /**
@@ -99,17 +100,12 @@ public class ClientConfig {
     }
 
     /**
-     * @return chain of defaults to use.
+     * Render the defaults for this config.
+     *
+     * @param context generation context
      */
-    public ConfigProviderChain getDefaults() {
-        return defaults;
-    }
-
-    /**
-     * @return a literal default value to be rendered. Must result in an array of defaults in Ruby.
-     */
-    public String getDefaultLiteral() {
-        return defaultLiteral;
+    public String renderDefaults(GenerationContext context) {
+        return defaults.renderDefault(context);
     }
 
     /**
@@ -136,12 +132,7 @@ public class ClientConfig {
     public void addToConfigCollection(Set<ClientConfig> configCollection) {
         if (!configCollection.contains(this)) {
             configCollection.add(this);
-            if (defaults != null) {
-                defaults.getProviders().forEach((p) -> {
-                    p.providerFragment().getClientConfig()
-                            .forEach((c) -> c.addToConfigCollection(configCollection));
-                });
-            }
+            defaults.addToConfigCollection(configCollection);
         }
     }
 
@@ -163,10 +154,6 @@ public class ClientConfig {
         return Objects.hash(getName(), getType());
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
     /**
      * Builder for ClientConfig.
      */
@@ -176,9 +163,12 @@ public class ClientConfig {
         private String documentation;
         private String documentationDefaultValue;
         private String documentationType;
-        private ConfigProviderChain defaults;
-        private String defaultLiteral;
+        private ConfigDefaults defaults;
         private boolean allowOperationOverride = false;
+
+        protected Builder() {
+
+        }
 
         /**
          * @param name name of the config option.
@@ -208,7 +198,7 @@ public class ClientConfig {
         }
 
         /**
-         * @param defaultValue an optional default value
+         * @param defaultValue an optional default value to be use in documentation.
          * @return this builder
          */
         public Builder documentationDefaultValue(String defaultValue) {
@@ -242,7 +232,14 @@ public class ClientConfig {
          * @return this builder
          */
         public Builder defaultPrimitiveValue(String value) {
-            this.defaults = new ConfigProviderChain.Builder().staticProvider(value).build();
+            validateDefaultNotSet();
+            this.defaults = ConfigProviderChain.builder().staticProvider(value).build();
+            return this;
+        }
+
+        public Builder defaultDynamicValue(String rubyDefaultBlock) {
+            validateDefaultNotSet();
+            this.defaults = ConfigProviderChain.builder().dynamicProvider(rubyDefaultBlock).build();
             return this;
         }
 
@@ -251,7 +248,8 @@ public class ClientConfig {
          * @return this builder
          */
         public Builder defaultValue(String value) {
-            this.defaults = new ConfigProviderChain.Builder()
+            validateDefaultNotSet();
+            this.defaults = ConfigProviderChain.builder()
                     .dynamicProvider("proc { " + value + " }")
                     .build();
             return this;
@@ -261,11 +259,8 @@ public class ClientConfig {
          * @param defaults chain of default providers to use.
          * @return this builder.
          */
-        public Builder defaults(ConfigProviderChain defaults) {
-            if (defaultLiteral != null) {
-                throw new IllegalArgumentException("ConfigProviderChain defaults are incompatible "
-                        + "with defaultLiteral. You must provide only one.");
-            }
+        public Builder defaults(ConfigDefaults defaults) {
+            validateDefaultNotSet();
             this.defaults = defaults;
             return this;
         }
@@ -275,17 +270,20 @@ public class ClientConfig {
          * @return this builder
          */
         public Builder defaultLiteral(String defaultLiteral) {
-            if (defaults != null) {
-                throw new IllegalArgumentException("ConfigProviderChain defaults are incompatible "
-                        + "with defaultLiteral. You must provide only one.");
-            }
-            this.defaultLiteral = defaultLiteral;
+            validateDefaultNotSet();
+            this.defaults = new DefaultLiteral(defaultLiteral);
             return this;
         }
 
         @Override
         public ClientConfig build() {
             return new ClientConfig(this);
+        }
+
+        private void validateDefaultNotSet() {
+            if (defaults != null) {
+                throw new IllegalArgumentException("ConfigDefaults have already been set.");
+            }
         }
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.ruby.codegen.config;
 
 import java.util.Objects;
 import java.util.Set;
+import software.amazon.smithy.ruby.codegen.ClientFragment;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -238,6 +239,12 @@ public class ClientConfig {
         }
 
         public Builder defaultDynamicValue(String rubyDefaultBlock) {
+            validateDefaultNotSet();
+            this.defaults = ConfigProviderChain.builder().dynamicProvider(rubyDefaultBlock).build();
+            return this;
+        }
+
+        public Builder defaultDynamicValue(ClientFragment rubyDefaultBlock) {
             validateDefaultNotSet();
             this.defaults = ConfigProviderChain.builder().dynamicProvider(rubyDefaultBlock).build();
             return this;

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigDefaults.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigDefaults.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen.config;
+
+import java.util.Optional;
+import java.util.Set;
+import software.amazon.smithy.ruby.codegen.GenerationContext;
+
+/**
+ * Represents the default values for a ClientConfig.
+ */
+public interface ConfigDefaults {
+    /**
+     * Render the defaults for this config value.
+     *
+     * @param context generation context
+     * @return rendered default.  Must be an array of defaults (callable/literals)
+     */
+    String renderDefault(GenerationContext context);
+
+    /**
+     * @return a string if there should be documentation for the default.
+     */
+    Optional<String> getDocumentationDefault();
+
+    /**
+     * @param documentationDefault default value to add to documentation.
+     */
+    void setDocumentationDefault(String documentationDefault);
+
+    /**
+     * Add any dependent ClientConfig to the collection.
+     * ConfigDefaults may depend on other ClientConfig (eg, creating a logger may use a log_level config).
+     *
+     * @param configCollection collection to add dependent config to.
+     */
+    void addToConfigCollection(Set<ClientConfig> configCollection);
+}

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigProvider.java
@@ -21,6 +21,9 @@ import software.amazon.smithy.ruby.codegen.ClientFragment;
 public interface ConfigProvider {
 
     /**
+     * Config defaults may depend on other config (eg a logger that uses log_level).
+     * The ClientFragment can be used to express these dependencies.
+     *
      * @return the provider rendered into Ruby code
      */
     ClientFragment providerFragment();

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/DefaultLiteral.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/DefaultLiteral.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen.config;
+
+import java.util.Optional;
+import java.util.Set;
+import software.amazon.smithy.ruby.codegen.GenerationContext;
+
+public class DefaultLiteral implements ConfigDefaults {
+
+    private String documentationDefault;
+    private final String defaultLiteral;
+
+    public DefaultLiteral(String defaultLiteral) {
+        this.defaultLiteral = defaultLiteral;
+    }
+
+    @Override
+    public String renderDefault(GenerationContext context) {
+        return defaultLiteral;
+    }
+
+    @Override
+    public Optional<String> getDocumentationDefault() {
+        return Optional.ofNullable(documentationDefault);
+    }
+
+    @Override
+    public void setDocumentationDefault(String documentationDefault) {
+        this.documentationDefault = documentationDefault;
+    }
+
+    @Override
+    public void addToConfigCollection(Set<ClientConfig> configCollection) {
+
+    }
+}

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
@@ -135,16 +135,8 @@ public class ConfigGenerator extends RubyGeneratorBase {
                 .openBlock("@defaults ||= {");
 
         clientConfigList.forEach(clientConfig -> {
-            if (clientConfig.getDefaults() == null) {
-                if (clientConfig.getDefaultLiteral() != null) {
-                    writer.write("$L: $L,", clientConfig.getName(), clientConfig.getDefaultLiteral());
-                }
-            } else {
-                String defaults = clientConfig.getDefaults().getProviders().stream()
-                        .map((p) -> p.providerFragment().render(context))
-                        .collect(Collectors.joining(","));
-                writer.write("$L: [$L],", clientConfig.getName(), defaults);
-            }
+            writer.write("$L: $L,", clientConfig.getName(), clientConfig.renderDefaults(context));
+
         });
 
         writer

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RequestCompression.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RequestCompression.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.traits.RequestCompressionTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyIntegration;
 import software.amazon.smithy.ruby.codegen.config.ClientConfig;
-import software.amazon.smithy.ruby.codegen.config.ConfigProviderChain;
 import software.amazon.smithy.ruby.codegen.middleware.Middleware;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareStackStep;
@@ -44,15 +43,12 @@ public class RequestCompression implements RubyIntegration {
 
     @Override
     public void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
-        ClientConfig disableRequestCompression = (new ClientConfig.Builder())
+        ClientConfig disableRequestCompression = ClientConfig.builder()
                 .name("disable_request_compression")
                 .type("Boolean")
-                .defaultValue("false")
+                .defaultPrimitiveValue("false")
                 .documentation("When set to 'true' the request body will not be compressed for supported operations.")
                 .allowOperationOverride()
-                .defaults(new ConfigProviderChain.Builder()
-                        .staticProvider("false")
-                        .build())
                 .build();
 
         String minCompressionDocumentation = """
@@ -60,18 +56,15 @@ public class RequestCompression implements RubyIntegration {
                 The value must be non-negative integer value between 0 and 10485780 bytes inclusive.
                 """;
 
-        ClientConfig requestMinCompressionSizeBytes = (new ClientConfig.Builder())
+        ClientConfig requestMinCompressionSizeBytes = ClientConfig.builder()
                 .name("request_min_compression_size_bytes")
                 .type("Integer")
-                .defaultValue("10240")
                 .documentation(minCompressionDocumentation)
                 .allowOperationOverride()
-                .defaults(new ConfigProviderChain.Builder()
-                        .staticProvider("10240")
-                        .build())
+                .defaultPrimitiveValue("10240")
                 .build();
 
-        Middleware compression = (new Middleware.Builder())
+        Middleware compression = Middleware.builder()
                 .operationPredicate(((model, service, operation) -> operation.hasTrait(RequestCompressionTrait.class)))
                 .operationParams((ctx, operation) -> {
                     Map<String, String> params = new HashMap<>();

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/Middleware.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/Middleware.java
@@ -82,6 +82,10 @@ public final class Middleware {
         this.writeAdditionalFiles = builder.writeAdditionalFiles;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     /**
      * @return the Ruby class to use for the middleware.
      */
@@ -125,7 +129,7 @@ public final class Middleware {
     }
 
     /**
-     * @param model model
+     * @param model   model
      * @param service service to test for
      * @return true if this middleware should be included for the service
      */
@@ -134,9 +138,8 @@ public final class Middleware {
     }
 
     /**
-     *
-     * @param model model
-     * @param service service to test for
+     * @param model     model
+     * @param service   service to test for
      * @param operation operation in the service to test for
      * @return true if this midldeware should be included for this operation/service
      */
@@ -147,8 +150,9 @@ public final class Middleware {
 
     /**
      * Generate code to add this middleware to an operation method.
-     * @param writer writer
-     * @param context generation context
+     *
+     * @param writer    writer
+     * @param context   generation context
      * @param operation operation to add to
      */
     public void renderAdd(RubyCodeWriter writer, GenerationContext context,
@@ -158,15 +162,12 @@ public final class Middleware {
 
     /**
      * Write additional files required by this middleware.
+     *
      * @param context generation context
      * @return List of additional files written out
      */
     public List<String> writeAdditionalFiles(GenerationContext context) {
         return writeAdditionalFiles.writeAdditionalFiles(context);
-    }
-
-    public static Builder builder() {
-        return new Builder();
     }
 
     @FunctionalInterface
@@ -265,6 +266,9 @@ public final class Middleware {
         private RenderAdd renderAdd = DEFAULT_RENDER_ADD;
         private WriteAdditionalFiles writeAdditionalFiles =
                 (context) -> Collections.emptyList();
+
+        protected Builder() {
+        }
 
         /**
          * @param klass the Ruby class of the Middleware

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
@@ -40,7 +40,6 @@ import software.amazon.smithy.ruby.codegen.Hearth;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.config.ClientConfig;
-import software.amazon.smithy.ruby.codegen.config.ConfigProviderChain;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -173,13 +172,13 @@ public class MiddlewareBuilder {
         ApplicationTransport transport = context.applicationTransport();
         SymbolProvider symbolProvider = context.symbolProvider();
 
-        Middleware initialize = (new Middleware.Builder())
+        Middleware initialize = Middleware.builder()
                 .klass(Hearth.INITIALIZE_MIDDLEWARE)
                 .step(MiddlewareStackStep.INITIALIZE)
                 .order(Byte.MIN_VALUE)
                 .build();
 
-        ClientConfig validateInput = (new ClientConfig.Builder())
+        ClientConfig validateInput = ClientConfig.builder()
                 .name("validate_input")
                 .type("Boolean")
                 .defaultPrimitiveValue("true")
@@ -187,7 +186,7 @@ public class MiddlewareBuilder {
                         "When `true`, request parameters are validated using the modeled shapes.")
                 .build();
 
-        Middleware validate = (new Middleware.Builder())
+        Middleware validate = Middleware.builder()
                 .klass(Hearth.VALIDATE_MIDDLEWARE)
                 .step(MiddlewareStackStep.VALIDATE)
                 .operationParams((ctx, operation) -> {
@@ -201,7 +200,7 @@ public class MiddlewareBuilder {
                 .addConfig(validateInput)
                 .build();
 
-        ClientConfig disableHostPrefix = (new ClientConfig.Builder())
+        ClientConfig disableHostPrefix = ClientConfig.builder()
                 .name("disable_host_prefix")
                 .type("Boolean")
                 .defaultPrimitiveValue("false")
@@ -209,7 +208,7 @@ public class MiddlewareBuilder {
                         "When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.")
                 .build();
 
-        Middleware hostPrefix = (new Middleware.Builder())
+        Middleware hostPrefix = Middleware.builder()
                 .klass("Hearth::Middleware::HostPrefix")
                 .step(MiddlewareStackStep.BUILD)
                 .relative(new Middleware.Relative(
@@ -236,7 +235,7 @@ public class MiddlewareBuilder {
                 })
                 .build();
 
-        ClientConfig stubResponses = (new ClientConfig.Builder())
+        ClientConfig stubResponses = ClientConfig.builder()
                 .name("stub_responses")
                 .type("Boolean")
                 .defaultPrimitiveValue("false")
@@ -244,7 +243,7 @@ public class MiddlewareBuilder {
                         "Enable response stubbing for testing. See {Hearth::ClientStubs#stub_responses}.")
                 .build();
 
-        ClientConfig retryStrategy = (new ClientConfig.Builder())
+        ClientConfig retryStrategy = ClientConfig.builder()
                 .name("retry_strategy")
                 .type("Hearth::Retry::Strategy")
                 .documentationDefaultValue("Hearth::Retry::Standard.new")
@@ -263,14 +262,14 @@ public class MiddlewareBuilder {
                 )
                 .build();
 
-        Middleware retry = (new Middleware.Builder())
+        Middleware retry = Middleware.builder()
                 .klass(Hearth.RETRY_MIDDLEWARE)
                 .step(MiddlewareStackStep.RETRY)
                 .addConfig(retryStrategy)
                 .addParam("error_inspector_class", transport.getErrorInspector())
                 .build();
 
-        Middleware send = (new Middleware.Builder())
+        Middleware send = Middleware.builder()
                 .klass(Hearth.SEND_MIDDLEWARE)
                 .step(MiddlewareStackStep.SEND)
                 .addParam("client",
@@ -300,25 +299,22 @@ public class MiddlewareBuilder {
     }
 
     private Collection<? extends ClientConfig> getDefaultClientConfig() {
-        ClientConfig logger = (new ClientConfig.Builder())
+        ClientConfig logger = ClientConfig.builder()
                 .name("logger")
                 .type("Logger")
                 .documentationDefaultValue("Logger.new($stdout, level: cfg.log_level)")
-                .defaults(new ConfigProviderChain.Builder()
-                        .dynamicProvider("proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) }")
-                        .build()
-                )
+                .defaultDynamicValue("proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) }")
                 .documentation("The Logger instance to use for logging.")
                 .build();
 
-        ClientConfig logLevel = (new ClientConfig.Builder())
+        ClientConfig logLevel = ClientConfig.builder()
                 .name("log_level")
                 .type("Symbol")
                 .defaultPrimitiveValue(":info")
                 .documentation("The default log level to use with the Logger.")
                 .build();
 
-        ClientConfig plugins = (new ClientConfig.Builder())
+        ClientConfig plugins = ClientConfig.builder()
                 .name("plugins")
                 .type("Hearth::PluginList")
                 .defaultValue("Hearth::PluginList.new")
@@ -328,7 +324,7 @@ public class MiddlewareBuilder {
                         + "Plugins may modify the provided config.")
                 .build();
 
-        ClientConfig interceptors = (new ClientConfig.Builder())
+        ClientConfig interceptors = ClientConfig.builder()
                 .name("interceptors")
                 .type("Hearth::InterceptorList")
                 .defaultValue("Hearth::InterceptorList.new")

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
@@ -37,7 +37,7 @@ public class RailsIntegration implements RubyIntegration {
 
     @Override
     public void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
-        Middleware requestId = (new Middleware.Builder())
+        Middleware requestId = Middleware.builder()
                 .klass("Middleware::RequestId")
                 .step(MiddlewareStackStep.PARSE)
                 .rubySource("smithy-ruby-rails-codegen/middleware/request_id.rb")


### PR DESCRIPTION

*Description of changes:*
#152 introduced default literals, but did so in a way that introduced a lot of messy code/duplication.  This PR cleans that up and consolidates defaults behind a consistent interface.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
