### PR TITLE
Clean ups

### DIFF
--- a/codegen/.rubocop.yml
+++ b/codegen/.rubocop.yml
@@ -24,4 +24,3 @@ Style/FrozenStringLiteralComment:
 Lint/EmptyClass:
   Exclude:
     - 'smithy-ruby-codegen-test/integration-specs/params_spec.rb'
-

--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -64,12 +64,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :api_key_auth),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -134,12 +133,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :basic_auth),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -204,12 +202,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :bearer_auth),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -287,12 +284,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :create_high_score),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -360,12 +356,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :delete_high_score),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -430,12 +425,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :digest_auth),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -509,12 +503,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :get_high_score),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -587,12 +580,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :list_high_scores),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -670,12 +662,11 @@ module HighScoreService
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :update_high_score),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -101,10 +101,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :all_query_string_types),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -174,10 +173,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :constant_and_variable_query_string),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -247,10 +245,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :constant_query_string),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -327,10 +324,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :document_type),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -405,10 +401,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :document_type_as_payload),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -472,10 +467,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :empty_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -543,10 +537,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :endpoint_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -616,10 +609,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :endpoint_with_host_label_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -692,10 +684,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :greeting_with_errors),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -768,10 +759,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_payload_traits),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -842,10 +832,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_payload_traits_with_media_type),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -921,10 +910,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_payload_with_structure),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -998,10 +986,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_prefix_headers),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1068,10 +1055,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_prefix_headers_in_response),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1138,10 +1124,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_request_with_float_labels),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1208,10 +1193,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_request_with_greedy_label_in_path),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1286,10 +1270,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_request_with_labels),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1363,10 +1346,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_request_with_labels_and_timestamp_format),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1431,10 +1413,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :http_response_code),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1502,10 +1483,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :ignore_query_params_in_response),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1622,10 +1602,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :input_and_output_with_headers),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1712,10 +1691,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :json_enums),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1829,10 +1807,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :json_maps),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1934,10 +1911,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :json_unions),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2109,10 +2085,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :kitchen_sink_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2180,10 +2155,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :media_type_header),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2252,10 +2226,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :nested_attributes_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2331,10 +2304,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :null_and_empty_headers_client),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2411,10 +2383,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :null_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2482,10 +2453,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :omits_null_serializes_empty_string),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2552,10 +2522,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :operation_with_optional_input_output),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2623,10 +2592,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :query_idempotency_token_auto_fill),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2697,10 +2665,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :query_params_as_string_list_map),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2766,10 +2733,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :streaming_operation),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2849,10 +2815,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :timestamp_format_headers),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -2923,10 +2888,9 @@ module RailsJson
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :operation____789_bad_name),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -72,10 +72,9 @@ module Weather
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :get_city),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -150,10 +149,9 @@ module Weather
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :get_city_image),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -217,10 +215,9 @@ module Weather
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :get_current_time),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -301,10 +298,9 @@ module Weather
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :get_forecast),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -390,10 +386,9 @@ module Weather
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :list_cities),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -464,10 +459,9 @@ module Weather
         error_inspector_class: Hearth::HTTP::ErrorInspector
       )
       stack.use(Hearth::Middleware::Auth,
-        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
         auth_params: Auth::Params.new(operation_name: :operation____789_bad_name),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: {}
+        auth_schemes: options.fetch(:auth_schemes, config.auth_schemes)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -9,8 +9,8 @@
 
 require 'stringio'
 
-require_relative 'middleware/relative_middleware'
 require_relative 'middleware/test_middleware'
+require_relative 'middleware/relative_middleware'
 require_relative 'plugins/test_plugin'
 
 module WhiteLabel
@@ -83,13 +83,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :custom_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -208,13 +207,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :defaults_test, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -285,13 +283,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :endpoint_operation, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -364,13 +361,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :endpoint_with_host_label_operation, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -437,13 +433,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :http_api_key_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -510,13 +505,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :http_basic_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -583,13 +577,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :http_bearer_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -656,13 +649,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :http_digest_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -871,13 +863,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :kitchen_sink, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -948,13 +939,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :mixin_test, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1021,13 +1011,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :no_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1094,13 +1083,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :optional_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1167,13 +1155,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :ordered_auth, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1245,13 +1232,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :paginators_test, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1323,13 +1309,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :paginators_test_with_items, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1399,13 +1384,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :relative_middleware_operation, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1481,13 +1465,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :request_compression_operation, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1561,13 +1544,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :request_compression_streaming_operation, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1636,13 +1618,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :streaming_operation, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1711,13 +1692,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :streaming_with_length, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1787,13 +1767,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :waiters_test, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,
@@ -1866,13 +1845,12 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Auth,
         auth_params: Auth::Params.new(operation_name: :operation____paginators_test_with_bad_names, custom_param: 'custom_value'),
-        http_api_key_identity_resolver: options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver),
         auth_resolver: options.fetch(:auth_resolver, config.auth_resolver),
-        identity_resolver_map: { http_login_identity_resolver: Hearth::Identities::HTTPLogin, http_custom_auth_identity_resolver: Auth::HTTPCustomAuthIdentity, http_bearer_identity_resolver: Hearth::Identities::HTTPBearer, http_api_key_identity_resolver: Hearth::Identities::HTTPApiKey },
-        http_custom_auth_identity_resolver: options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
         auth_schemes: options.fetch(:auth_schemes, config.auth_schemes),
-        http_bearer_identity_resolver: options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
-        http_login_identity_resolver: options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver)
+        Hearth::Identities::HTTPLogin => options.fetch(:http_login_identity_resolver, config.http_login_identity_resolver),
+        Auth::HTTPCustomAuthIdentity => options.fetch(:http_custom_auth_identity_resolver, config.http_custom_auth_identity_resolver),
+        Hearth::Identities::HTTPBearer => options.fetch(:http_bearer_identity_resolver, config.http_bearer_identity_resolver),
+        Hearth::Identities::HTTPApiKey => options.fetch(:http_api_key_identity_resolver, config.http_api_key_identity_resolver)
       )
       stack.use(Hearth::Middleware::Sign)
       stack.use(Hearth::Middleware::Parse,

--- a/codegen/smithy-ruby-codegen-test-utils/src/main/java/software/amazon/smithy/ruby/codegen/integrations/FakeProtocolIntegration.java
+++ b/codegen/smithy-ruby-codegen-test-utils/src/main/java/software/amazon/smithy/ruby/codegen/integrations/FakeProtocolIntegration.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  * Provide support for whitelabel testing (implements fakeProtocol).
  */
 @SmithyInternalApi
-public class TestIntegration implements RubyIntegration {
+public class FakeProtocolIntegration implements RubyIntegration {
 
     @Override
     public List<ProtocolGenerator> getProtocolGenerators() {

--- a/codegen/smithy-ruby-codegen-test-utils/src/main/resources/META-INF/services/software.amazon.smithy.ruby.codegen.RubyIntegration
+++ b/codegen/smithy-ruby-codegen-test-utils/src/main/resources/META-INF/services/software.amazon.smithy.ruby.codegen.RubyIntegration
@@ -1,2 +1,2 @@
-software.amazon.smithy.ruby.codegen.integrations.TestIntegration
+software.amazon.smithy.ruby.codegen.integrations.FakeProtocolIntegration
 software.amazon.smithy.ruby.codegen.integrations.WhiteLabelTestIntegration

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
@@ -15,14 +15,12 @@
 
 package software.amazon.smithy.ruby.codegen;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.directed.CreateContextDirective;
@@ -59,10 +57,7 @@ import software.amazon.smithy.ruby.codegen.generators.YardOptsGenerator;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
 
 public class DirectedRubyCodegen
-    implements DirectedCodegen<GenerationContext, RubySettings, RubyIntegration> {
-
-    private static final Logger LOGGER =
-            Logger.getLogger(DirectedRubyCodegen.class.getName());
+        implements DirectedCodegen<GenerationContext, RubySettings, RubyIntegration> {
 
     private TypesFileBlockGenerator typesFileBlockGenerator;
 
@@ -81,35 +76,34 @@ public class DirectedRubyCodegen
                 .collect(Collectors.toList());
 
         Map<ShapeId, ProtocolGenerator> supportedProtocols = ProtocolGenerator
-            .collectSupportedProtocolGenerators(integrations);
+                .collectSupportedProtocolGenerators(integrations);
 
         ShapeId protocol = directive.settings()
-            .resolveServiceProtocol(service, model, supportedProtocols.keySet());
+                .resolveServiceProtocol(service, model, supportedProtocols.keySet());
 
         Optional<ProtocolGenerator> protocolGenerator =
-            ProtocolGenerator.resolve(protocol, integrations);
+                ProtocolGenerator.resolve(protocol, integrations);
 
         ApplicationTransport applicationTransport;
 
         if (protocolGenerator.isPresent()) {
             applicationTransport =
-                protocolGenerator.get().getApplicationTransport();
+                    protocolGenerator.get().getApplicationTransport();
         } else {
             applicationTransport = ApplicationTransport
-                .createDefaultHttpApplicationTransport();
+                    .createDefaultHttpApplicationTransport();
         }
 
         GenerationContext context = new GenerationContext(
-            directive.settings(),
-            directive.fileManifest(),
-            integrations,
-            model,
-            service,
-            protocol,
-            protocolGenerator,
-            applicationTransport,
-            collectDependencies(model, service, protocol, directive.settings(), integrations),
-            directive.symbolProvider());
+                directive.settings(),
+                directive.fileManifest(),
+                integrations,
+                model,
+                service,
+                protocol,
+                protocolGenerator,
+                applicationTransport,
+                directive.symbolProvider());
 
         return context;
     }
@@ -225,25 +219,5 @@ public class DirectedRubyCodegen
     public void customizeAfterIntegrations(CustomizeDirective<GenerationContext, RubySettings> directive) {
         // Close all module blocks for types.rb and types.rbs files
         this.typesFileBlockGenerator.closeAllBlocks();
-    }
-
-    private Set<RubyDependency> collectDependencies(
-        Model model,
-        ServiceShape service,
-        ShapeId protocol,
-        RubySettings settings,
-        List<RubyIntegration> integrations
-    ) {
-        Set<RubyDependency> rubyDependencies = new HashSet<>();
-        rubyDependencies.addAll(settings.getBaseDependencies());
-        rubyDependencies.addAll(
-            integrations.stream()
-                .map((integration) -> integration
-                        .additionalGemDependencies(settings, model, service, protocol))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet())
-        );
-
-        return rubyDependencies;
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/GenerationContext.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/GenerationContext.java
@@ -15,11 +15,12 @@
 
 package software.amazon.smithy.ruby.codegen;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.CodegenContext;
@@ -146,39 +147,39 @@ public class GenerationContext implements CodegenContext<RubySettings, RubyCodeW
     }
 
     /**
-     * @return set of RubyDependencies
+     * @return Set of RubyDependencies from the base and all integrations
      */
-    public List<RubyDependency> getRubyDependencies() {
-        List<RubyDependency> rubyDependencies = new ArrayList<>();
+    public Set<RubyDependency> getRubyDependencies() {
+        Set<RubyDependency> rubyDependencies = new HashSet<>();
         rubyDependencies.addAll(settings().getBaseDependencies());
         rubyDependencies.addAll(
                 integrations.stream()
-                        .map((integration) -> integration.additionalGemDependencies(this))
+                        .map((integration) -> integration.getAdditionalGemDependencies(this))
                         .flatMap(Collection::stream)
-                        .collect(Collectors.toList())
+                        .collect(Collectors.toSet())
         );
-        return Collections.unmodifiableList(rubyDependencies);
+        return Collections.unmodifiableSet(rubyDependencies);
     }
 
     /**
-     * @return list of all RubyRuntimePlugins from all integrations
+     * @return Set of all RubyRuntimePlugins from all integrations
      */
-    public List<RubyRuntimePlugin> getRuntimePlugins() {
+    public Set<RubyRuntimePlugin> getRuntimePlugins() {
         return integrations.stream()
                 .map((i) -> i.getRuntimePlugins(this))
                 .flatMap(List::stream)
-                .collect(Collectors.toUnmodifiableList());
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     /**
-     * @return list of all AuthSchemes from all integrations and the application transport.
+     * @return Set of all AuthSchemes from all integrations and the application transport.
      */
-    public List<AuthScheme> getAuthSchemes() {
-        List<AuthScheme> authSchemes = new ArrayList<>(applicationTransport.defaultAuthSchemes());
+    public Set<AuthScheme> getAuthSchemes() {
+        Set<AuthScheme> authSchemes = new HashSet<>(applicationTransport.defaultAuthSchemes());
         authSchemes.add(AnonymousAuthSchemeFactory.build());
         integrations().forEach((i) -> {
             i.getAdditionalAuthSchemes(this).forEach((s) -> authSchemes.add(s));
         });
-        return Collections.unmodifiableList(authSchemes);
+        return Collections.unmodifiableSet(authSchemes);
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ProtocolGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ProtocolGenerator.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.ruby.codegen.config.ClientConfig;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
@@ -55,7 +53,7 @@ public interface ProtocolGenerator {
      * each operation must have a class that implements the
      * `build(req, input:)` method.
      *
-     * @param context context to use for generation
+     * @param context - Generation context to process within
      */
     void generateBuilders(GenerationContext context);
 
@@ -65,7 +63,7 @@ public interface ProtocolGenerator {
      * each operation must have a class that implements the
      * `parse(resp)` method.
      *
-     * @param context context to use for generation
+     * @param context - Generation context to process within
      */
     void generateParsers(GenerationContext context);
 
@@ -76,7 +74,7 @@ public interface ProtocolGenerator {
      * as well as classes for ApiError, ApiServiceError,
      * and ApiClientError.
      *
-     * @param context context to use for generation
+     * @param context - Generation context to process within
      */
     void generateErrors(GenerationContext context);
 
@@ -86,12 +84,12 @@ public interface ProtocolGenerator {
      * should define a class for each operation
      * that implements the `default` and `stub(resp, stub:)` method.
      *
-     * @param context context to use for generation
+     * @param context - Generation context to process within
      */
     void generateStubs(GenerationContext context);
 
     /**
-     * Return all of the Middleware to be registered on the Client.
+     * Return all the Middleware to be registered on the Client.
      *
      * @param middlewareBuilder - Client middleware to be modified
      * @param context           - Generation context to process within
@@ -114,7 +112,7 @@ public interface ProtocolGenerator {
     /**
      * Writes additional files.
      *
-     * @param context - context for generation
+     * @param context - Generation context to process within
      * @return List of relative paths generated to be added to module requires.
      */
     default List<String> writeAdditionalFiles(GenerationContext context) {
@@ -124,20 +122,15 @@ public interface ProtocolGenerator {
     /**
      * Adds additional Gem Dependencies.
      *
-     * @param rubySettings       - generation settings
-     * @param finalResolvedModel - the resolved model (post any transforms)
-     * @param service            - service to generate for
-     * @param protocol           - the resolved protocol
+     * @param context - Generation context to process within
      * @return Set of ruby dependencies to be added
      */
-    default Set<RubyDependency> additionalGemDependencies(
-            RubySettings rubySettings, Model finalResolvedModel,
-            ServiceShape service, ShapeId protocol) {
+    default Set<RubyDependency> additionalGemDependencies(GenerationContext context) {
         return Collections.emptySet();
     }
 
     static Map<ShapeId, ProtocolGenerator> collectSupportedProtocolGenerators(
-        List<RubyIntegration> integrations
+            List<RubyIntegration> integrations
     ) {
         Map<ShapeId, ProtocolGenerator> generators = new HashMap<>();
         for (RubyIntegration integration : integrations) {
@@ -149,8 +142,8 @@ public interface ProtocolGenerator {
     }
 
     static Optional<ProtocolGenerator> resolve(
-        ShapeId protocol,
-        List<RubyIntegration> integrations
+            ShapeId protocol,
+            List<RubyIntegration> integrations
     ) {
         for (RubyIntegration integration : integrations) {
             Optional<ProtocolGenerator> pg = integration.getProtocolGenerators()

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
@@ -63,33 +63,42 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, RubyCod
     }
 
     /**
-     * Returns a list of additional (non-middleware) Config
-     * to be added to the generated Client.
+     * Returns a List of additional (non-middleware) Config to be added to the generated Client.
      *
      * @param context - Generation context to process within
-     * @return list of additional config
+     * @return List of ClientConfig to be added
      */
     default List<ClientConfig> getAdditionalClientConfig(GenerationContext context) {
         return Collections.emptyList();
     }
 
     /**
-     * Returns a list of RubyRuntimePlugins to be added to the generated Client.
+     * Returns a List of RubyRuntimePlugins to be added to the generated Client.
      *
      * @param context - Generation context to process within
-     * @return list of RubyRuntimePlugins
+     * @return List of RubyRuntimePlugins
      */
     default List<RubyRuntimePlugin> getRuntimePlugins(GenerationContext context) {
         return Collections.emptyList();
     }
 
     /**
-     * Returns a list of additional Auth Schemes to be added to the generated Auth module.
+     * Returns a List of additional Auth Schemes to be added to the generated Auth module and middleware.
      *
      * @param context - Generation context to process within
-     * @return list of additional AuthScheme
+     * @return List of AuthSchemes to be added
      */
     default List<AuthScheme> getAdditionalAuthSchemes(GenerationContext context) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a List of additional Gem Dependencies.
+     *
+     * @param context - Generation context to process within
+     * @return List of RubyDependency to be added
+     */
+    default List<RubyDependency> getAdditionalGemDependencies(GenerationContext context) {
         return Collections.emptyList();
     }
 
@@ -100,16 +109,6 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, RubyCod
      * @return List of relative paths generated to be added to module requires.
      */
     default List<String> writeAdditionalFiles(GenerationContext context) {
-        return Collections.emptyList();
-    }
-
-    /**
-     * Adds additional Gem Dependencies.
-     *
-     * @param context - Generation context to process within
-     * @return Set of ruby dependencies to be added
-     */
-    default List<RubyDependency> additionalGemDependencies(GenerationContext context) {
         return Collections.emptyList();
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
@@ -17,11 +17,9 @@ package software.amazon.smithy.ruby.codegen;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.ruby.codegen.auth.AuthScheme;
 import software.amazon.smithy.ruby.codegen.config.ClientConfig;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
@@ -87,6 +85,7 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, RubyCod
 
     /**
      * Returns a list of additional Auth Schemes to be added to the generated Auth module.
+     *
      * @param context - Generation context to process within
      * @return list of additional AuthScheme
      */
@@ -97,7 +96,7 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, RubyCod
     /**
      * Writes additional files.
      *
-     * @param context - context for generation
+     * @param context - Generation context to process within
      * @return List of relative paths generated to be added to module requires.
      */
     default List<String> writeAdditionalFiles(GenerationContext context) {
@@ -107,15 +106,10 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, RubyCod
     /**
      * Adds additional Gem Dependencies.
      *
-     * @param rubySettings       - generation settings
-     * @param finalResolvedModel - the resolved model (post any transforms)
-     * @param service            - service to generate for
-     * @param protocol           - the resolved protocol
+     * @param context - Generation context to process within
      * @return Set of ruby dependencies to be added
      */
-    default Set<RubyDependency> additionalGemDependencies(
-            RubySettings rubySettings, Model finalResolvedModel,
-            ServiceShape service, ShapeId protocol) {
-        return Collections.emptySet();
+    default List<RubyDependency> additionalGemDependencies(GenerationContext context) {
+        return Collections.emptyList();
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyRuntimePlugin.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyRuntimePlugin.java
@@ -72,6 +72,24 @@ public class RubyRuntimePlugin {
         String renderAdd(GenerationContext context);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof RubyRuntimePlugin)) {
+            return false;
+        }
+
+        RubyRuntimePlugin other = (RubyRuntimePlugin) o;
+
+        return this.renderAdd.equals(other.renderAdd);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(renderAdd);
+    }
+
     /**
      * Builder for {@link RubyRuntimePlugin}.
      */

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyRuntimePlugin.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyRuntimePlugin.java
@@ -72,24 +72,6 @@ public class RubyRuntimePlugin {
         String renderAdd(GenerationContext context);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        } else if (!(o instanceof RubyRuntimePlugin)) {
-            return false;
-        }
-
-        RubyRuntimePlugin other = (RubyRuntimePlugin) o;
-
-        return this.renderAdd.equals(other.renderAdd);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(renderAdd);
-    }
-
     /**
      * Builder for {@link RubyRuntimePlugin}.
      */

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/auth/AuthScheme.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/auth/AuthScheme.java
@@ -134,6 +134,24 @@ public final class AuthScheme {
         Map<String, String> extractProperties(Trait trait);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof AuthScheme)) {
+            return false;
+        }
+
+        AuthScheme other = (AuthScheme) o;
+
+        return this.shapeId.equals(other.shapeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shapeId);
+    }
+
     public static class Builder implements SmithyBuilder<AuthScheme> {
         private ShapeId shapeId;
         private String rubyAuthScheme;

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
@@ -257,6 +257,10 @@ public class ClientConfig {
             return this;
         }
 
+        /**
+         * @param rubyDefaultBlock a single, dynamic default value to use.
+         * @return this builder
+         */
         public Builder defaultDynamicValue(String rubyDefaultBlock) {
             validateDefaultNotSet();
             this.defaults = ConfigProviderChain.builder().dynamicProvider(rubyDefaultBlock).build();

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/AuthGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/AuthGenerator.java
@@ -46,7 +46,7 @@ public class AuthGenerator extends RubyGeneratorBase {
 
     private final Set<OperationShape> operations;
     private final ServiceShape service;
-    private final List<AuthScheme> authSchemes;
+    private final Set<AuthScheme> authSchemes;
 
     public AuthGenerator(ContextualDirective<GenerationContext, RubySettings> directive) {
         super(directive);

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/GemspecGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/GemspecGenerator.java
@@ -45,12 +45,14 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class GemspecGenerator {
 
     private final GenerationContext context;
+    private final Set<RubyDependency> rubyDependencies;
 
     /**
      * @param context generation context
      */
     public GemspecGenerator(GenerationContext context) {
         this.context = context;
+        this.rubyDependencies = context.getRubyDependencies();
     }
 
     /**
@@ -73,11 +75,11 @@ public class GemspecGenerator {
                 .call(() -> {
                     // determine set of indirect dependencies - covered by requiring another
                     Set<RubyDependency> indirectDependencies = new HashSet<>();
-                    context.getRubyDependencies().forEach(rubyDependency -> {
+                    rubyDependencies.forEach(rubyDependency -> {
                         indirectDependencies.addAll(rubyDependency.getRubyDependencies());
                     });
 
-                    context.getRubyDependencies().forEach((rubyDependency -> {
+                    rubyDependencies.forEach((rubyDependency -> {
                         if (rubyDependency.getType() != RubyDependency.Type.STANDARD_LIBRARY
                                 && !indirectDependencies.contains(rubyDependency)) {
                             writer.write("spec.add_runtime_dependency '$L', '$L'",
@@ -87,9 +89,7 @@ public class GemspecGenerator {
                 })
                 .closeBlock("end");
 
-        String fileName = settings.getGemName() + "/" + settings.getGemName()
-                + ".gemspec";
-
+        String fileName = settings.getGemName() + "/" + settings.getGemName() + ".gemspec";
         fileManifest.writeFile(fileName, writer.toString());
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ModuleGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ModuleGenerator.java
@@ -38,10 +38,12 @@ public class ModuleGenerator {
 
     private final GenerationContext context;
     private final RubySettings settings;
+    private final Set<RubyDependency> rubyDependencies;
 
     public ModuleGenerator(ContextualDirective<GenerationContext, RubySettings> directive) {
         this.context = directive.context();
         this.settings = directive.settings();
+        this.rubyDependencies = context.getRubyDependencies();
     }
 
     public void render() {
@@ -57,11 +59,11 @@ public class ModuleGenerator {
             writer.preamble().includeRequires();
             // determine set of indirect dependencies - covered by requiring another
             Set<RubyDependency> indirectDependencies = new HashSet<>();
-            context.getRubyDependencies().forEach(rubyDependency -> {
+            rubyDependencies.forEach(rubyDependency -> {
                 indirectDependencies.addAll(rubyDependency.getRubyDependencies());
             });
 
-            context.getRubyDependencies().forEach((rubyDependency -> {
+            rubyDependencies.forEach((rubyDependency -> {
                 if (!indirectDependencies.contains(rubyDependency)) {
                     writer.write("require '$L'", rubyDependency.getImportPath());
                 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/factories/AuthMiddlewareFactory.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/factories/AuthMiddlewareFactory.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.ruby.codegen.middleware.factories;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -41,12 +40,12 @@ public final class AuthMiddlewareFactory {
         Map<ShapeId, Trait> serviceAuthSchemes =
                 ServiceIndex.of(context.model()).getAuthSchemes(context.service());
 
-        List<AuthScheme> authSchemesList = context.getAuthSchemes();
+        Set<AuthScheme> authSchemesSet = context.getAuthSchemes();
         Set<ClientConfig> clientConfigSet = new HashSet<>();
         Map<String, String> identityResolvers = new HashMap<>();
 
         serviceAuthSchemes.forEach((shapeId, trait) -> {
-            AuthScheme authScheme = authSchemesList.stream()
+            AuthScheme authScheme = authSchemesSet.stream()
                     .filter(s -> s.getShapeId().equals(shapeId))
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException("No auth scheme found for " + shapeId));
@@ -99,7 +98,7 @@ public final class AuthMiddlewareFactory {
                     authParamsMap.put("operation_name",
                             RubyFormatter.asSymbol(symbolProvider.toSymbol(operation).getName()));
 
-                    authSchemesList.forEach(s -> {
+                    authSchemesSet.forEach(s -> {
                         Map<String, String> additionalAuthParams = s.getAdditionalAuthParams();
                         additionalAuthParams.entrySet().forEach(e -> {
                             authParamsMap.put(e.getKey(), e.getValue());

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/factories/AuthMiddlewareFactory.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/factories/AuthMiddlewareFactory.java
@@ -41,8 +41,8 @@ public final class AuthMiddlewareFactory {
                 ServiceIndex.of(context.model()).getAuthSchemes(context.service());
 
         Set<AuthScheme> authSchemesSet = context.getAuthSchemes();
-        Set<ClientConfig> clientConfigSet = new HashSet<>();
-        Map<String, String> identityResolvers = new HashMap<>();
+        Set<ClientConfig> identityResolversConfigSet = new HashSet<>();
+        Map<String, String> identityResolversMap = new HashMap<>();
 
         serviceAuthSchemes.forEach((shapeId, trait) -> {
             AuthScheme authScheme = authSchemesSet.stream()
@@ -52,9 +52,9 @@ public final class AuthMiddlewareFactory {
 
             ClientConfig config = authScheme.getIdentityResolverConfig();
             if (config != null) {
-                clientConfigSet.add(config);
+                identityResolversConfigSet.add(config);
                 String symbolizedName = RubyFormatter.toSnakeCase(config.getName());
-                identityResolvers.put(authScheme.getRubyIdentityType(), symbolizedName);
+                identityResolversMap.put(authScheme.getRubyIdentityType(), symbolizedName);
             }
         });
 
@@ -112,7 +112,7 @@ public final class AuthMiddlewareFactory {
                     params.put("auth_params", authParams);
 
                     String identityResolverMapHash = "{%s}".formatted(
-                            identityResolvers.entrySet().stream()
+                            identityResolversMap.entrySet().stream()
                                     .map(e -> "%s: %s".formatted(e.getValue(), e.getKey()))
                                     .reduce((a, b) -> a + ", " + b)
                                     .map(s -> " " + s + " ")
@@ -121,7 +121,7 @@ public final class AuthMiddlewareFactory {
 
                     return params;
                 });
-        clientConfigSet.forEach(authBuilder::addConfig);
+        identityResolversConfigSet.forEach(authBuilder::addConfig);
 
         return authBuilder.build();
     }

--- a/hearth/lib/hearth/middleware/auth.rb
+++ b/hearth/lib/hearth/middleware/auth.rb
@@ -15,24 +15,17 @@ module Hearth
       #  parameters that may be used to resolve auth options.
       # @param [Array<Hearth::AuthScheme::Base>] auth_schemes A list of
       #  auth schemes to consider for authentication.
-      # @param [Hash<Symbol, Class>] identity_resolver_map A map of identity
-      #  resolver config names to identity types.
-      def initialize(app, auth_resolver:, auth_params:, auth_schemes:,
-                     identity_resolver_map:, **kwargs)
+      def initialize(app, auth_resolver:, auth_params:, auth_schemes:, **kwargs)
         @app = app
         @auth_resolver = auth_resolver
         @auth_params = auth_params
         @auth_schemes = auth_schemes.to_h { |s| [s.scheme_id, s] }
-        @identity_resolver_map = identity_resolver_map
 
         @identity_resolvers = {}
         kwargs.each do |key, value|
-          next unless key.end_with?('_identity_resolver')
+          next unless key.superclass == Hearth::Identities::Base
 
-          type = @identity_resolver_map[key]
-          raise "Unknown identity resolver type #{key}" unless type
-
-          @identity_resolvers[type] = value
+          @identity_resolvers[key] = value
         end
       end
 

--- a/hearth/spec/hearth/middleware/auth_spec.rb
+++ b/hearth/spec/hearth/middleware/auth_spec.rb
@@ -6,13 +6,6 @@ module Hearth
       let(:app) { double('app', call: output) }
       let(:auth_resolver) { double('auth_resolver') }
       let(:auth_params) { double('auth_params') }
-      let(:identity_resolver_map) do
-        {
-          http_api_key_identity_resolver: Identities::HTTPApiKey,
-          http_bearer_identity_resolver: Identities::HTTPBearer,
-          http_login_identity_resolver: Identities::HTTPLogin
-        }
-      end
 
       let(:http_api_key_auth_scheme) { AuthSchemes::HTTPApiKey.new }
       let(:http_bearer_auth_scheme) { AuthSchemes::HTTPBearer.new }
@@ -45,10 +38,10 @@ module Hearth
 
       let(:identity_resolvers) do
         {
-          http_api_key_identity_resolver:
+          Hearth::Identities::HTTPApiKey =>
             double('http_api_key_identity_resolver'),
-          http_bearer_identity_resolver: http_bearer_identity_resolver,
-          http_login_identity_resolver:
+          Hearth::Identities::HTTPBearer => http_bearer_identity_resolver,
+          Hearth::Identities::HTTPLogin =>
             double('http_login_identity_resolver')
         }
       end
@@ -63,7 +56,6 @@ module Hearth
           auth_resolver: auth_resolver,
           auth_params: auth_params,
           auth_schemes: auth_schemes,
-          identity_resolver_map: identity_resolver_map,
           **identity_resolvers
         )
       end
@@ -76,46 +68,17 @@ module Hearth
           expect(schemes.values).to eq(auth_schemes)
         end
 
-        it 'converts identity resolvers to a hash for lookup' do
-          resolvers = subject.instance_variable_get(:@identity_resolvers)
-          expect(resolvers).to be_a(Hash)
-          expect(resolvers.keys).to eq [
-            Identities::HTTPApiKey,
-            Identities::HTTPBearer,
-            Identities::HTTPLogin
-          ]
-          expect(resolvers.values).to eq [
-            identity_resolvers[:http_api_key_identity_resolver],
-            identity_resolvers[:http_bearer_identity_resolver],
-            identity_resolvers[:http_login_identity_resolver]
-          ]
-        end
-
-        it 'ignores keys that do not end with _identity_resolver' do
+        it 'ignores keys that are not Hearth::Identities::Base' do
           auth = Auth.new(
             app,
             auth_resolver: auth_resolver,
             auth_params: auth_params,
             auth_schemes: auth_schemes,
-            identity_resolver_map: identity_resolver_map,
-            some_kwarg: double('some_kwarg')
+            Class => double('some_kwarg')
           )
           resolvers = auth.instance_variable_get(:@identity_resolvers)
           expect(resolvers).to be_a(Hash)
           expect(resolvers).to be_empty
-        end
-
-        it 'raises an error for unknown identity types' do
-          expect do
-            Auth.new(
-              app,
-              auth_resolver: auth_resolver,
-              auth_params: auth_params,
-              auth_schemes: auth_schemes,
-              identity_resolver_map: identity_resolver_map,
-              foo_identity_resolver: double('foo_identity_resolver')
-            )
-          end.to raise_error(/foo_identity_resolver/)
         end
       end
 
@@ -134,9 +97,9 @@ module Hearth
 
         let(:identity_resolvers) do
           {
-            http_api_key_identity_resolver:
+            Hearth::Identities::HTTPApiKey =>
               double('http_api_key_identity_resolver'),
-            http_bearer_identity_resolver: http_bearer_identity_resolver
+            Hearth::Identities::HTTPBearer => http_bearer_identity_resolver
           }
         end
 


### PR DESCRIPTION
Clean ups from the previous identity PRs.

* Rename test integration
* Ruby dependencies takes context
* Integrations return List only
* Remove identity_providers_map by using classes as keys in middleware