### PR TITLE
Allow authschemes to add ClientConfig

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/auth/AuthScheme.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/auth/AuthScheme.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.ruby.codegen.auth;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,8 @@ public final class AuthScheme {
     private final ExtractProperties extractIdentityProperties;
     private final Map<String, String> identityProperties;
 
+    private final List<ClientConfig> additionalConfig;
+
     private AuthScheme(Builder builder) {
         this.shapeId = Objects.requireNonNull(builder.shapeId);
         this.rubyAuthScheme = Objects.requireNonNull(builder.rubyAuthScheme);
@@ -51,6 +54,7 @@ public final class AuthScheme {
         this.signerProperties = builder.signerProperties;
         this.extractIdentityProperties = builder.extractIdentityProperties;
         this.identityProperties = builder.identityProperties;
+        this.additionalConfig = List.copyOf(builder.additionalConfig);
     }
 
     public static Builder builder() {
@@ -122,6 +126,10 @@ public final class AuthScheme {
         return identityProperties;
     }
 
+    public List<ClientConfig> getAdditionalConfig() {
+        return additionalConfig;
+    }
+
     @FunctionalInterface
     /**
      * Extract properties from a trait.
@@ -163,6 +171,8 @@ public final class AuthScheme {
         private ExtractProperties extractIdentityProperties = (trait) -> Collections.emptyMap();
         private Map<String, String> signerProperties = new HashMap<>();
         private Map<String, String> identityProperties = new HashMap<>();
+
+        private List<ClientConfig> additionalConfig = new ArrayList<>();
 
         protected Builder() {
         }
@@ -265,6 +275,16 @@ public final class AuthScheme {
          */
         public Builder putIdentityProperty(String key, String value) {
             this.identityProperties.put(key, value);
+            return this;
+        }
+
+        /**
+         * Add ClientConfig that this AuthScheme depends on.
+         * @param config client config to include when this auth scheme is used.
+         * @return returns the builder.
+         */
+        public Builder additionalConfig(ClientConfig config) {
+            this.additionalConfig.add(config);
             return this;
         }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/factories/AuthMiddlewareFactory.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/factories/AuthMiddlewareFactory.java
@@ -43,7 +43,7 @@ public final class AuthMiddlewareFactory {
         Map<ShapeId, Trait> serviceAuthSchemes =
                 ServiceIndex.of(context.model()).getAuthSchemes(context.service());
 
-        Set<AuthScheme> authSchemesSet = context.getAuthSchemes();
+        Set<AuthScheme> authSchemesSet = context.getAllAuthSchemes();
         Set<ClientConfig> identityResolversConfigSet = new HashSet<>();
         Map<String, String> identityResolversMap = new HashMap<>();
 
@@ -118,6 +118,9 @@ public final class AuthMiddlewareFactory {
                 });
 
         identityResolversConfigSet.forEach(authBuilder::addConfig);
+        context.getServiceAuthSchemes().forEach(authScheme ->  {
+            authScheme.getAdditionalConfig().forEach(authBuilder::addConfig);
+        });
         return authBuilder.build();
     }
 


### PR DESCRIPTION
*Description of changes:*
Allows authschemes to add additional clientConfig that should included when the Authscheme is applied to a service.

Supports cases like adding `region` for `sigv4`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
