### PR TITLE
Generate spec_helper and allow rubyIntegrations to customize it

### DIFF
--- a/codegen/projections/high_score_service/spec/spec_helper.rb
+++ b/codegen/projections/high_score_service/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# WARNING ABOUT GENERATED CODE
+#
+# This file was code generated using smithy-ruby.
+# https://github.com/smithy-lang/smithy-ruby
+#
+# WARNING ABOUT GENERATED CODE
+
+$:.unshift(File.expand_path('../lib', __dir__))
+
+require 'high_score_service'
+
+require 'rspec'

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -9,7 +9,7 @@
 
 require 'cgi'
 
-require 'rails_json'
+require_relative 'spec_helper'
 
 module RailsJson
   describe Client do

--- a/codegen/projections/rails_json/spec/spec_helper.rb
+++ b/codegen/projections/rails_json/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# WARNING ABOUT GENERATED CODE
+#
+# This file was code generated using smithy-ruby.
+# https://github.com/smithy-lang/smithy-ruby
+#
+# WARNING ABOUT GENERATED CODE
+
+$:.unshift(File.expand_path('../lib', __dir__))
+
+require 'rails_json'
+
+require 'rspec'

--- a/codegen/projections/weather/spec/spec_helper.rb
+++ b/codegen/projections/weather/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# WARNING ABOUT GENERATED CODE
+#
+# This file was code generated using smithy-ruby.
+# https://github.com/smithy-lang/smithy-ruby
+#
+# WARNING ABOUT GENERATED CODE
+
+$:.unshift(File.expand_path('../lib', __dir__))
+
+require 'weather'
+
+require 'rspec'

--- a/codegen/projections/white_label/lib/white_label/config.rb
+++ b/codegen/projections/white_label/lib/white_label/config.rb
@@ -35,7 +35,7 @@ module WhiteLabel
   #   @option args [Hearth::IdentityResolver] :http_custom_auth_identity_resolver
   #     A Hearth::IdentityResolver that returns a Auth::HTTPCustomAuthIdentity for operations modeled with the smithy.api#httpBasicAuth auth scheme.
   #   @option args [Hearth::IdentityResolver] :http_login_identity_resolver
-  #     A Hearth::IdentityResolver that returns a Hearth::Identities::HTTPLogin for operations modeled with the smithy.api#httpDigestAuth auth scheme.
+  #     A Hearth::IdentityResolver that returns a Hearth::Identities::HTTPLogin for operations modeled to use it.
   #   @option args [Hearth::InterceptorList] :interceptors (Hearth::InterceptorList.new)
   #     A list of Interceptors to apply to the client.  Interceptors are a generic
   #     extension point that allows injecting logic at specific stages of execution

--- a/codegen/projections/white_label/spec/endpoint_spec.rb
+++ b/codegen/projections/white_label/spec/endpoint_spec.rb
@@ -7,7 +7,7 @@
 #
 # WARNING ABOUT GENERATED CODE
 
-require 'white_label'
+require_relative 'spec_helper'
 
 module WhiteLabel
   module Endpoint

--- a/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
@@ -370,3 +370,4 @@ structure ClientError {
 @error("server")
 @retryable(throttling: true)
 structure ServerError {}
+

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
@@ -50,6 +50,7 @@ import software.amazon.smithy.ruby.codegen.generators.MiddlewareGenerator;
 import software.amazon.smithy.ruby.codegen.generators.ModuleGenerator;
 import software.amazon.smithy.ruby.codegen.generators.PaginatorsGenerator;
 import software.amazon.smithy.ruby.codegen.generators.ParamsGenerator;
+import software.amazon.smithy.ruby.codegen.generators.SpecHelperGenerator;
 import software.amazon.smithy.ruby.codegen.generators.SteepfileGenerator;
 import software.amazon.smithy.ruby.codegen.generators.StructureGenerator;
 import software.amazon.smithy.ruby.codegen.generators.TypesFileBlockGenerator;
@@ -242,6 +243,7 @@ public class DirectedRubyCodegen
         new GemspecGenerator(context).render();
         new YardOptsGenerator(context).render();
         new SteepfileGenerator(context).render();
+        new SpecHelperGenerator(context).render();
 
         if (context.applicationTransport().isHttpTransport()) {
             HttpProtocolTestGenerator testGenerator =

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
@@ -135,9 +135,19 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, RubyCod
 
     /**
      * Additional Smithy rules engine auth scheme bindings supported by this integration.
+     *
      * @return list of rules engine auth scheme bindings.
      */
     default List<AuthSchemeBinding> authSchemeBindings() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Hook to write additional ruby code to the generated spec_helper.rb.
+     *
+     * @param writer code writer to write additional spec helper code with.
+     */
+    default void writeAdditionalSpecHelper(RubyCodeWriter writer) {
+
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -367,7 +367,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
 
         specWriter
                 .preamble()
-                .write("require '$L'", settings.getGemName())
+                .write("require_relative 'spec_helper'")
                 .write("")
                 .addModule(settings.getModule())
                 .addModule("Endpoint")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -301,7 +301,10 @@ public class EndpointGenerator extends RubyGeneratorBase {
                     .call(() -> {
                         for (Parameter p : endpointRuleSet.getParameters()) {
                             String paramName = p.getName().toString();
-                            if (staticContextParams.containsKey(paramName)) {
+                            if (p.isBuiltIn()) {
+                                context.getBuiltInBinding(p.getBuiltIn().get())
+                                        .get().renderBuild(writer, context, operation);
+                            } else if (staticContextParams.containsKey(paramName)) {
                                 StaticContextParamDefinition def = staticContextParams.get(paramName);
                                 String value;
                                 if (def.getValue().isStringNode()) {
@@ -321,9 +324,6 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                 writer.write("params.$1L = input.$2L unless input.$2L.nil?",
                                         RubyFormatter.toSnakeCase(paramName),
                                         contextParams.get(paramName));
-                            } else if (p.isBuiltIn()) {
-                                context.getBuiltInBinding(p.getBuiltIn().get())
-                                        .get().renderBuild(writer, context, operation);
                             }
                             // some parameters may not have bindings for an operation, leave them as nil or default
                         }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -91,7 +91,7 @@ public class HttpProtocolTestGenerator {
         writer
                 .preamble()
                 .includeRequires()
-                .write("require '$L'\n", settings.getGemName())
+                .write("require_relative 'spec_helper'")
                 .write("")
                 .openBlock("module $L", settings.getModule())
                 .openBlock("describe Client do")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/SpecHelperGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/SpecHelperGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen.generators;
+
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.ruby.codegen.GenerationContext;
+import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
+
+public class SpecHelperGenerator {
+    private final GenerationContext context;
+
+    public SpecHelperGenerator(GenerationContext context) {
+        this.context = context;
+    }
+
+    public void render() {
+        FileManifest fileManifest = context.fileManifest();
+        RubyCodeWriter writer = new RubyCodeWriter(context.settings().getModule());
+
+        writer
+                .preamble()
+                .call(() -> context.integrations().forEach(i -> i.writeAdditionalSpecHelper(writer)))
+                .write("$$:.unshift(File.expand_path('../lib', __dir__))")
+                .write("")
+                .write("require '$L'\n", context.settings().getGemName())
+                .write("require 'rspec'")
+                .write("");
+
+        String fileName = context.settings().getGemName() + "/spec/spec_helper.rb";
+        fileManifest.writeFile(fileName, writer.toString());
+    }
+
+}


### PR DESCRIPTION

*Description of changes:*
Generates a spec_helper.rb for each service and allows RubyIntegrations to add customizations to it.  Protocol tests and endpoint tests now use this spec_helper

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
