### PR TITLE
Implement defaults in type initialize

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -228,6 +228,36 @@ module RailsJson
       end
     end
 
+    class Dialog
+      def self.build(input)
+        data = {}
+        data[:language] = input[:language] unless input[:language].nil?
+        data[:greeting] = input[:greeting] unless input[:greeting].nil?
+        data[:farewell] = Builders::Farewell.build(input[:farewell]) unless input[:farewell].nil?
+        data
+      end
+    end
+
+    class DialogList
+      def self.build(input)
+        data = []
+        input.each do |element|
+          data << Builders::Dialog.build(element) unless element.nil?
+        end
+        data
+      end
+    end
+
+    class DialogMap
+      def self.build(input)
+        data = {}
+        input.each do |key, value|
+          data[key] = Builders::Dialog.build(value) unless value.nil?
+        end
+        data
+      end
+    end
+
     class DocumentType
       def self.build(http_req, input:)
         http_req.http_method = 'PUT'
@@ -302,6 +332,14 @@ module RailsJson
         data = {}
         data[:label] = input[:label] unless input[:label].nil?
         http_req.body = StringIO.new(Hearth::JSON.dump(data))
+      end
+    end
+
+    class Farewell
+      def self.build(input)
+        data = {}
+        data[:phrase] = input[:phrase] unless input[:phrase].nil?
+        data
       end
     end
 
@@ -964,6 +1002,17 @@ module RailsJson
       end
     end
 
+    class OperationWithNestedStructure
+      def self.build(http_req, input:)
+        http_req.http_method = 'POST'
+        http_req.append_path('/OperationWithNestedStructure')
+        http_req.headers['Content-Type'] = 'application/json'
+        data = {}
+        data[:top_level] = Builders::TopLevel.build(input[:top_level]) unless input[:top_level].nil?
+        http_req.body = StringIO.new(Hearth::JSON.dump(data))
+      end
+    end
+
     class PayloadConfig
       def self.build(input)
         data = {}
@@ -1380,6 +1429,16 @@ module RailsJson
         input.each do |element|
           data << Hearth::TimeHelper.to_date_time(element) unless element.nil?
         end
+        data
+      end
+    end
+
+    class TopLevel
+      def self.build(input)
+        data = {}
+        data[:dialog] = Builders::Dialog.build(input[:dialog]) unless input[:dialog].nil?
+        data[:dialog_list] = Builders::DialogList.build(input[:dialog_list]) unless input[:dialog_list].nil?
+        data[:dialog_map] = Builders::DialogMap.build(input[:dialog_map]) unless input[:dialog_map].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -97,6 +97,14 @@ module RailsJson
       end
     end
 
+    class ClientOptionalDefaults
+      def self.build(input)
+        data = {}
+        data[:member] = input[:member] unless input[:member].nil?
+        data
+      end
+    end
+
     class ConstantAndVariableQueryString
       def self.build(http_req, input:)
         http_req.http_method = 'GET'
@@ -132,6 +140,41 @@ module RailsJson
       def self.build(http_req, input:)
         http_req.http_method = 'POST'
         http_req.append_path('/DatetimeOffsets')
+      end
+    end
+
+    class Defaults
+      def self.build(input)
+        data = {}
+        data[:default_string] = input[:default_string] unless input[:default_string].nil?
+        data[:default_boolean] = input[:default_boolean] unless input[:default_boolean].nil?
+        data[:default_list] = Builders::TestStringList.build(input[:default_list]) unless input[:default_list].nil?
+        data[:default_document_map] = input[:default_document_map] unless input[:default_document_map].nil?
+        data[:default_document_string] = input[:default_document_string] unless input[:default_document_string].nil?
+        data[:default_document_boolean] = input[:default_document_boolean] unless input[:default_document_boolean].nil?
+        data[:default_document_list] = input[:default_document_list] unless input[:default_document_list].nil?
+        data[:default_null_document] = input[:default_null_document] unless input[:default_null_document].nil?
+        data[:default_timestamp] = Hearth::TimeHelper.to_date_time(input[:default_timestamp]) unless input[:default_timestamp].nil?
+        data[:default_blob] = ::Base64::encode64(input[:default_blob]).strip unless input[:default_blob].nil?
+        data[:default_byte] = input[:default_byte] unless input[:default_byte].nil?
+        data[:default_short] = input[:default_short] unless input[:default_short].nil?
+        data[:default_integer] = input[:default_integer] unless input[:default_integer].nil?
+        data[:default_long] = input[:default_long] unless input[:default_long].nil?
+        data[:default_float] = Hearth::NumberHelper.serialize(input[:default_float]) unless input[:default_float].nil?
+        data[:default_double] = Hearth::NumberHelper.serialize(input[:default_double]) unless input[:default_double].nil?
+        data[:default_map] = Builders::TestStringMap.build(input[:default_map]) unless input[:default_map].nil?
+        data[:default_enum] = input[:default_enum] unless input[:default_enum].nil?
+        data[:default_int_enum] = input[:default_int_enum] unless input[:default_int_enum].nil?
+        data[:empty_string] = input[:empty_string] unless input[:empty_string].nil?
+        data[:false_boolean] = input[:false_boolean] unless input[:false_boolean].nil?
+        data[:empty_blob] = ::Base64::encode64(input[:empty_blob]).strip unless input[:empty_blob].nil?
+        data[:zero_byte] = input[:zero_byte] unless input[:zero_byte].nil?
+        data[:zero_short] = input[:zero_short] unless input[:zero_short].nil?
+        data[:zero_integer] = input[:zero_integer] unless input[:zero_integer].nil?
+        data[:zero_long] = input[:zero_long] unless input[:zero_long].nil?
+        data[:zero_float] = Hearth::NumberHelper.serialize(input[:zero_float]) unless input[:zero_float].nil?
+        data[:zero_double] = Hearth::NumberHelper.serialize(input[:zero_double]) unless input[:zero_double].nil?
+        data
       end
     end
 
@@ -907,6 +950,20 @@ module RailsJson
       end
     end
 
+    class OperationWithDefaults
+      def self.build(http_req, input:)
+        http_req.http_method = 'POST'
+        http_req.append_path('/OperationWithDefaults')
+        http_req.headers['Content-Type'] = 'application/json'
+        data = {}
+        data[:defaults] = Builders::Defaults.build(input[:defaults]) unless input[:defaults].nil?
+        data[:client_optional_defaults] = Builders::ClientOptionalDefaults.build(input[:client_optional_defaults]) unless input[:client_optional_defaults].nil?
+        data[:top_level_default] = input[:top_level_default] unless input[:top_level_default].nil?
+        data[:other_top_level_default] = input[:other_top_level_default] unless input[:other_top_level_default].nil?
+        http_req.body = StringIO.new(Hearth::JSON.dump(data))
+      end
+    end
+
     class PayloadConfig
       def self.build(input)
         data = {}
@@ -1280,6 +1337,26 @@ module RailsJson
         data = Builders::PayloadConfig.build(input[:payload_config]) unless input[:payload_config].nil?
         http_req.body = StringIO.new(Hearth::JSON.dump(data || {}))
         http_req.headers['x-amz-test-id'] = input[:test_id] unless input[:test_id].nil? || input[:test_id].empty?
+      end
+    end
+
+    class TestStringList
+      def self.build(input)
+        data = []
+        input.each do |element|
+          data << element unless element.nil?
+        end
+        data
+      end
+    end
+
+    class TestStringMap
+      def self.build(input)
+        data = {}
+        input.each do |key, value|
+          data[key] = value unless value.nil?
+        end
+        data
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -1998,6 +1998,112 @@ module RailsJson
       output
     end
 
+    # @param [Hash | Types::OperationWithDefaultsInput] params
+    #   Request parameters for this operation.
+    #   See {Types::OperationWithDefaultsInput#initialize} for available parameters.
+    # @param [Hash] options
+    #   Request option override of configuration. See {Config#initialize} for available options.
+    #   Some configurations cannot be overridden.
+    # @return [Hearth::Output]
+    # @example Request syntax with placeholder values
+    #   resp = client.operation_with_defaults(
+    #     defaults: {
+    #       default_string: 'defaultString',
+    #       default_boolean: false,
+    #       default_list: [
+    #         'member'
+    #       ],
+    #       default_document_map: {
+    #         'nil' => nil,
+    #         'number' => 123.0,
+    #         'string' => 'value',
+    #         'boolean' => true,
+    #         'array' => [],
+    #         'map' => {}
+    #       },
+    #       default_timestamp: Time.now,
+    #       default_blob: 'defaultBlob',
+    #       default_byte: 1,
+    #       default_short: 1,
+    #       default_integer: 1,
+    #       default_long: 1,
+    #       default_float: 1.0,
+    #       default_double: 1.0,
+    #       default_map: {
+    #         'key' => 'value'
+    #       },
+    #       default_enum: 'FOO', # accepts ["FOO", "BAR", "BAZ"]
+    #       default_int_enum: 1,
+    #       empty_string: 'emptyString',
+    #       false_boolean: false,
+    #       empty_blob: 'emptyBlob',
+    #       zero_byte: 1,
+    #       zero_short: 1,
+    #       zero_integer: 1,
+    #       zero_long: 1,
+    #       zero_float: 1.0,
+    #       zero_double: 1.0
+    #     },
+    #     client_optional_defaults: {
+    #       member: 1
+    #     },
+    #     top_level_default: 'topLevelDefault',
+    #     other_top_level_default: 1
+    #   )
+    # @example Response structure
+    #   resp.data #=> Types::OperationWithDefaultsOutput
+    #   resp.data.default_string #=> String
+    #   resp.data.default_boolean #=> Boolean
+    #   resp.data.default_list #=> Array<String>
+    #   resp.data.default_list[0] #=> String
+    #   resp.data.default_document_map #=> Hash, Array, String, Boolean, Numeric
+    #   resp.data.default_document_string #=> Hash, Array, String, Boolean, Numeric
+    #   resp.data.default_document_boolean #=> Hash, Array, String, Boolean, Numeric
+    #   resp.data.default_document_list #=> Hash, Array, String, Boolean, Numeric
+    #   resp.data.default_null_document #=> Hash, Array, String, Boolean, Numeric
+    #   resp.data.default_timestamp #=> Time
+    #   resp.data.default_blob #=> String
+    #   resp.data.default_byte #=> Integer
+    #   resp.data.default_short #=> Integer
+    #   resp.data.default_integer #=> Integer
+    #   resp.data.default_long #=> Integer
+    #   resp.data.default_float #=> Float
+    #   resp.data.default_double #=> Float
+    #   resp.data.default_map #=> Hash<String, String>
+    #   resp.data.default_map['key'] #=> String
+    #   resp.data.default_enum #=> String, one of ["FOO", "BAR", "BAZ"]
+    #   resp.data.default_int_enum #=> Integer
+    #   resp.data.empty_string #=> String
+    #   resp.data.false_boolean #=> Boolean
+    #   resp.data.empty_blob #=> String
+    #   resp.data.zero_byte #=> Integer
+    #   resp.data.zero_short #=> Integer
+    #   resp.data.zero_integer #=> Integer
+    #   resp.data.zero_long #=> Integer
+    #   resp.data.zero_float #=> Float
+    #   resp.data.zero_double #=> Float
+    def operation_with_defaults(params = {}, options = {})
+      response_body = ::StringIO.new
+      config = operation_config(options)
+      input = Params::OperationWithDefaultsInput.build(params, context: 'params')
+      stack = RailsJson::Middleware::OperationWithDefaults.build(config)
+      context = Hearth::Context.new(
+        request: Hearth::HTTP::Request.new(uri: URI('')),
+        response: Hearth::HTTP::Response.new(body: response_body),
+        logger: config.logger,
+        operation_name: :operation_with_defaults,
+        interceptors: config.interceptors
+      )
+      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] params: #{params}, options: #{options}")
+      output = stack.run(input, context)
+      if output.error
+        context.logger.error("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] #{output.error} (#{output.error.class})")
+        raise output.error
+      end
+      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] #{output.data}")
+      output
+    end
+
     # This operation defines a union with a Unit member.
     # @param [Hash | Types::PostPlayerActionInput] params
     #   Request parameters for this operation.

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -2104,6 +2104,56 @@ module RailsJson
       output
     end
 
+    # @param [Hash | Types::OperationWithNestedStructureInput] params
+    #   Request parameters for this operation.
+    #   See {Types::OperationWithNestedStructureInput#initialize} for available parameters.
+    # @param [Hash] options
+    #   Request option override of configuration. See {Config#initialize} for available options.
+    #   Some configurations cannot be overridden.
+    # @return [Hearth::Output]
+    # @example Request syntax with placeholder values
+    #   resp = client.operation_with_nested_structure(
+    #     top_level: {
+    #       dialog: {
+    #         language: 'language',
+    #         greeting: 'greeting',
+    #         farewell: {
+    #           phrase: 'phrase'
+    #         }
+    #       }, # required
+    #     } # required
+    #   )
+    # @example Response structure
+    #   resp.data #=> Types::OperationWithNestedStructureOutput
+    #   resp.data.dialog #=> Types::Dialog
+    #   resp.data.dialog.language #=> String
+    #   resp.data.dialog.greeting #=> String
+    #   resp.data.dialog.farewell #=> Types::Farewell
+    #   resp.data.dialog.farewell.phrase #=> String
+    #   resp.data.dialog_list #=> Array<Dialog>
+    #   resp.data.dialog_map #=> Hash<String, Dialog>
+    def operation_with_nested_structure(params = {}, options = {})
+      response_body = ::StringIO.new
+      config = operation_config(options)
+      input = Params::OperationWithNestedStructureInput.build(params, context: 'params')
+      stack = RailsJson::Middleware::OperationWithNestedStructure.build(config)
+      context = Hearth::Context.new(
+        request: Hearth::HTTP::Request.new(uri: URI('')),
+        response: Hearth::HTTP::Response.new(body: response_body),
+        logger: config.logger,
+        operation_name: :operation_with_nested_structure,
+        interceptors: config.interceptors
+      )
+      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] params: #{params}, options: #{options}")
+      output = stack.run(input, context)
+      if output.error
+        context.logger.error("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] #{output.error} (#{output.error.class})")
+        raise output.error
+      end
+      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] #{output.data}")
+      output
+    end
+
     # This operation defines a union with a Unit member.
     # @param [Hash | Types::PostPlayerActionInput] params
     #   Request parameters for this operation.

--- a/codegen/projections/rails_json/lib/rails_json/endpoint.rb
+++ b/codegen/projections/rails_json/lib/rails_json/endpoint.rb
@@ -382,6 +382,14 @@ module RailsJson
         end
       end
 
+      class OperationWithDefaults
+        def self.build(config, input, context)
+          params = Params.new
+          params.endpoint = config[:endpoint] unless config[:endpoint].nil?
+          params
+        end
+      end
+
       class PostPlayerAction
         def self.build(config, input, context)
           params = Params.new

--- a/codegen/projections/rails_json/lib/rails_json/endpoint.rb
+++ b/codegen/projections/rails_json/lib/rails_json/endpoint.rb
@@ -390,6 +390,14 @@ module RailsJson
         end
       end
 
+      class OperationWithNestedStructure
+        def self.build(config, input, context)
+          params = Params.new
+          params.endpoint = config[:endpoint] unless config[:endpoint].nil?
+          params
+        end
+      end
+
       class PostPlayerAction
         def self.build(config, input, context)
           params = Params.new

--- a/codegen/projections/rails_json/lib/rails_json/middleware.rb
+++ b/codegen/projections/rails_json/lib/rails_json/middleware.rb
@@ -2137,6 +2137,53 @@ module RailsJson
       end
     end
 
+    class OperationWithNestedStructure
+      def self.build(config)
+        stack = Hearth::MiddlewareStack.new
+        stack.use(Hearth::Middleware::Initialize)
+        stack.use(Hearth::Middleware::Validate,
+          validator: Validators::OperationWithNestedStructureInput,
+          validate_input: config.validate_input
+        )
+        stack.use(Hearth::Middleware::Build,
+          builder: Builders::OperationWithNestedStructure
+        )
+        stack.use(Hearth::Middleware::Auth,
+          auth_params: Auth::Params.new(operation_name: :operation_with_nested_structure),
+          auth_resolver: config.auth_resolver,
+          auth_schemes: config.auth_schemes
+        )
+        stack.use(Hearth::HTTP::Middleware::ContentLength)
+        stack.use(Hearth::Middleware::Endpoint,
+          param_builder: Endpoint::Parameters::OperationWithNestedStructure,
+          endpoint_resolver: config.endpoint_resolver,
+          endpoint: config.endpoint
+        )
+        stack.use(Hearth::Middleware::Retry,
+          retry_strategy: config.retry_strategy,
+          error_inspector_class: Hearth::HTTP::ErrorInspector
+        )
+        stack.use(Hearth::Middleware::Sign)
+        stack.use(Hearth::Middleware::Parse,
+          error_parser: Hearth::HTTP::ErrorParser.new(
+            error_module: Errors,
+            success_status: 200,
+            errors: []
+          ),
+          data_parser: Parsers::OperationWithNestedStructure
+        )
+        stack.use(Middleware::RequestId)
+        stack.use(Hearth::Middleware::Send,
+          stub_responses: config.stub_responses,
+          client: config.http_client,
+          stub_error_classes: [],
+          stub_data_class: Stubs::OperationWithNestedStructure,
+          stubs: config.stubs
+        )
+        stack
+      end
+    end
+
     class PostPlayerAction
       def self.build(config)
         stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/rails_json/lib/rails_json/middleware.rb
+++ b/codegen/projections/rails_json/lib/rails_json/middleware.rb
@@ -2090,6 +2090,53 @@ module RailsJson
       end
     end
 
+    class OperationWithDefaults
+      def self.build(config)
+        stack = Hearth::MiddlewareStack.new
+        stack.use(Hearth::Middleware::Initialize)
+        stack.use(Hearth::Middleware::Validate,
+          validator: Validators::OperationWithDefaultsInput,
+          validate_input: config.validate_input
+        )
+        stack.use(Hearth::Middleware::Build,
+          builder: Builders::OperationWithDefaults
+        )
+        stack.use(Hearth::Middleware::Auth,
+          auth_params: Auth::Params.new(operation_name: :operation_with_defaults),
+          auth_resolver: config.auth_resolver,
+          auth_schemes: config.auth_schemes
+        )
+        stack.use(Hearth::HTTP::Middleware::ContentLength)
+        stack.use(Hearth::Middleware::Endpoint,
+          param_builder: Endpoint::Parameters::OperationWithDefaults,
+          endpoint_resolver: config.endpoint_resolver,
+          endpoint: config.endpoint
+        )
+        stack.use(Hearth::Middleware::Retry,
+          retry_strategy: config.retry_strategy,
+          error_inspector_class: Hearth::HTTP::ErrorInspector
+        )
+        stack.use(Hearth::Middleware::Sign)
+        stack.use(Hearth::Middleware::Parse,
+          error_parser: Hearth::HTTP::ErrorParser.new(
+            error_module: Errors,
+            success_status: 200,
+            errors: []
+          ),
+          data_parser: Parsers::OperationWithDefaults
+        )
+        stack.use(Middleware::RequestId)
+        stack.use(Hearth::Middleware::Send,
+          stub_responses: config.stub_responses,
+          client: config.http_client,
+          stub_error_classes: [],
+          stub_data_class: Stubs::OperationWithDefaults,
+          stubs: config.stubs
+        )
+        stack
+      end
+    end
+
     class PostPlayerAction
       def self.build(config)
         stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -18,25 +18,25 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::AllQueryStringTypesInput, context: context)
         type = Types::AllQueryStringTypesInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.query_string = params[:query_string]
+        type.query_string = params[:query_string] unless params[:query_string].nil?
         type.query_string_list = StringList.build(params[:query_string_list], context: "#{context}[:query_string_list]") unless params[:query_string_list].nil?
         type.query_string_set = StringSet.build(params[:query_string_set], context: "#{context}[:query_string_set]") unless params[:query_string_set].nil?
-        type.query_byte = params[:query_byte]
-        type.query_short = params[:query_short]
-        type.query_integer = params[:query_integer]
+        type.query_byte = params[:query_byte] unless params[:query_byte].nil?
+        type.query_short = params[:query_short] unless params[:query_short].nil?
+        type.query_integer = params[:query_integer] unless params[:query_integer].nil?
         type.query_integer_list = IntegerList.build(params[:query_integer_list], context: "#{context}[:query_integer_list]") unless params[:query_integer_list].nil?
         type.query_integer_set = IntegerSet.build(params[:query_integer_set], context: "#{context}[:query_integer_set]") unless params[:query_integer_set].nil?
-        type.query_long = params[:query_long]
-        type.query_float = params[:query_float]&.to_f
-        type.query_double = params[:query_double]&.to_f
+        type.query_long = params[:query_long] unless params[:query_long].nil?
+        type.query_float = params[:query_float]&.to_f unless params[:query_float].nil?
+        type.query_double = params[:query_double]&.to_f unless params[:query_double].nil?
         type.query_double_list = DoubleList.build(params[:query_double_list], context: "#{context}[:query_double_list]") unless params[:query_double_list].nil?
-        type.query_boolean = params[:query_boolean]
+        type.query_boolean = params[:query_boolean] unless params[:query_boolean].nil?
         type.query_boolean_list = BooleanList.build(params[:query_boolean_list], context: "#{context}[:query_boolean_list]") unless params[:query_boolean_list].nil?
-        type.query_timestamp = params[:query_timestamp]
+        type.query_timestamp = params[:query_timestamp] unless params[:query_timestamp].nil?
         type.query_timestamp_list = TimestampList.build(params[:query_timestamp_list], context: "#{context}[:query_timestamp_list]") unless params[:query_timestamp_list].nil?
-        type.query_enum = params[:query_enum]
+        type.query_enum = params[:query_enum] unless params[:query_enum].nil?
         type.query_enum_list = FooEnumList.build(params[:query_enum_list], context: "#{context}[:query_enum_list]") unless params[:query_enum_list].nil?
-        type.query_integer_enum = params[:query_integer_enum]
+        type.query_integer_enum = params[:query_integer_enum] unless params[:query_integer_enum].nil?
         type.query_integer_enum_list = IntegerEnumList.build(params[:query_integer_enum_list], context: "#{context}[:query_integer_enum_list]") unless params[:query_integer_enum_list].nil?
         type.query_params_map_of_string_list = StringListMap.build(params[:query_params_map_of_string_list], context: "#{context}[:query_params_map_of_string_list]") unless params[:query_params_map_of_string_list].nil?
         type
@@ -57,9 +57,19 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
+      end
+    end
+
+    class ClientOptionalDefaults
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::ClientOptionalDefaults, context: context)
+        type = Types::ClientOptionalDefaults.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.member = params[:member] unless params[:member].nil?
+        type
       end
     end
 
@@ -68,8 +78,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::ComplexError, context: context)
         type = Types::ComplexError.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.header = params[:header]
-        type.top_level = params[:top_level]
+        type.header = params[:header] unless params[:header].nil?
+        type.top_level = params[:top_level] unless params[:top_level].nil?
         type.nested = ComplexNestedErrorData.build(params[:nested], context: "#{context}[:nested]") unless params[:nested].nil?
         type
       end
@@ -80,7 +90,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::ComplexNestedErrorData, context: context)
         type = Types::ComplexNestedErrorData.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type
       end
     end
@@ -90,8 +100,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::ConstantAndVariableQueryStringInput, context: context)
         type = Types::ConstantAndVariableQueryStringInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.baz = params[:baz]
-        type.maybe_set = params[:maybe_set]
+        type.baz = params[:baz] unless params[:baz].nil?
+        type.maybe_set = params[:maybe_set] unless params[:maybe_set].nil?
         type
       end
     end
@@ -110,7 +120,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::ConstantQueryStringInput, context: context)
         type = Types::ConstantQueryStringInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.hello = params[:hello]
+        type.hello = params[:hello] unless params[:hello].nil?
         type
       end
     end
@@ -138,7 +148,44 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::DatetimeOffsetsOutput, context: context)
         type = Types::DatetimeOffsetsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.datetime = params[:datetime]
+        type.datetime = params[:datetime] unless params[:datetime].nil?
+        type
+      end
+    end
+
+    class Defaults
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::Defaults, context: context)
+        type = Types::Defaults.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.default_string = params[:default_string] unless params[:default_string].nil?
+        type.default_boolean = params[:default_boolean] unless params[:default_boolean].nil?
+        type.default_list = TestStringList.build(params[:default_list], context: "#{context}[:default_list]") unless params[:default_list].nil?
+        type.default_document_map = params[:default_document_map] unless params[:default_document_map].nil?
+        type.default_document_string = params[:default_document_string] unless params[:default_document_string].nil?
+        type.default_document_boolean = params[:default_document_boolean] unless params[:default_document_boolean].nil?
+        type.default_document_list = params[:default_document_list] unless params[:default_document_list].nil?
+        type.default_null_document = params[:default_null_document] unless params[:default_null_document].nil?
+        type.default_timestamp = params[:default_timestamp] unless params[:default_timestamp].nil?
+        type.default_blob = params[:default_blob] unless params[:default_blob].nil?
+        type.default_byte = params[:default_byte] unless params[:default_byte].nil?
+        type.default_short = params[:default_short] unless params[:default_short].nil?
+        type.default_integer = params[:default_integer] unless params[:default_integer].nil?
+        type.default_long = params[:default_long] unless params[:default_long].nil?
+        type.default_float = params[:default_float]&.to_f unless params[:default_float].nil?
+        type.default_double = params[:default_double]&.to_f unless params[:default_double].nil?
+        type.default_map = TestStringMap.build(params[:default_map], context: "#{context}[:default_map]") unless params[:default_map].nil?
+        type.default_enum = params[:default_enum] unless params[:default_enum].nil?
+        type.default_int_enum = params[:default_int_enum] unless params[:default_int_enum].nil?
+        type.empty_string = params[:empty_string] unless params[:empty_string].nil?
+        type.false_boolean = params[:false_boolean] unless params[:false_boolean].nil?
+        type.empty_blob = params[:empty_blob] unless params[:empty_blob].nil?
+        type.zero_byte = params[:zero_byte] unless params[:zero_byte].nil?
+        type.zero_short = params[:zero_short] unless params[:zero_short].nil?
+        type.zero_integer = params[:zero_integer] unless params[:zero_integer].nil?
+        type.zero_long = params[:zero_long] unless params[:zero_long].nil?
+        type.zero_float = params[:zero_float]&.to_f unless params[:zero_float].nil?
+        type.zero_double = params[:zero_double]&.to_f unless params[:zero_double].nil?
         type
       end
     end
@@ -148,7 +195,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -159,7 +206,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -181,7 +228,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -223,7 +270,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::DocumentTypeAsPayloadInput, context: context)
         type = Types::DocumentTypeAsPayloadInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.document_value = params[:document_value]
+        type.document_value = params[:document_value] unless params[:document_value].nil?
         type
       end
     end
@@ -233,7 +280,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::DocumentTypeAsPayloadOutput, context: context)
         type = Types::DocumentTypeAsPayloadOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.document_value = params[:document_value]
+        type.document_value = params[:document_value] unless params[:document_value].nil?
         type
       end
     end
@@ -243,8 +290,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::DocumentTypeInput, context: context)
         type = Types::DocumentTypeInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string_value = params[:string_value]
-        type.document_value = params[:document_value]
+        type.string_value = params[:string_value] unless params[:string_value].nil?
+        type.document_value = params[:document_value] unless params[:document_value].nil?
         type
       end
     end
@@ -254,8 +301,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::DocumentTypeOutput, context: context)
         type = Types::DocumentTypeOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string_value = params[:string_value]
-        type.document_value = params[:document_value]
+        type.string_value = params[:string_value] unless params[:string_value].nil?
+        type.document_value = params[:document_value] unless params[:document_value].nil?
         type
       end
     end
@@ -265,7 +312,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -276,7 +323,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element&.to_f
+          data << element&.to_f unless element.nil?
         end
         data
       end
@@ -323,7 +370,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::EndpointWithHostLabelOperationInput, context: context)
         type = Types::EndpointWithHostLabelOperationInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.label = params[:label]
+        type.label = params[:label] unless params[:label].nil?
         type
       end
     end
@@ -342,7 +389,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -353,7 +400,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -364,7 +411,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -384,7 +431,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::FractionalSecondsOutput, context: context)
         type = Types::FractionalSecondsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.datetime = params[:datetime]
+        type.datetime = params[:datetime] unless params[:datetime].nil?
         type
       end
     end
@@ -394,7 +441,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::RenamedGreeting, context: context)
         type = Types::RenamedGreeting.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.salutation = params[:salutation]
+        type.salutation = params[:salutation] unless params[:salutation].nil?
         type
       end
     end
@@ -404,7 +451,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::GreetingStruct, context: context)
         type = Types::GreetingStruct.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.hi = params[:hi]
+        type.hi = params[:hi] unless params[:hi].nil?
         type
       end
     end
@@ -423,7 +470,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::GreetingWithErrorsOutput, context: context)
         type = Types::GreetingWithErrorsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.greeting = params[:greeting]
+        type.greeting = params[:greeting] unless params[:greeting].nil?
         type
       end
     end
@@ -451,7 +498,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpChecksumRequiredInput, context: context)
         type = Types::HttpChecksumRequiredInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type
       end
     end
@@ -461,7 +508,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpChecksumRequiredOutput, context: context)
         type = Types::HttpChecksumRequiredOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type
       end
     end
@@ -471,7 +518,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpEnumPayloadInput, context: context)
         type = Types::HttpEnumPayloadInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.payload = params[:payload]
+        type.payload = params[:payload] unless params[:payload].nil?
         type
       end
     end
@@ -481,7 +528,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpEnumPayloadOutput, context: context)
         type = Types::HttpEnumPayloadOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.payload = params[:payload]
+        type.payload = params[:payload] unless params[:payload].nil?
         type
       end
     end
@@ -491,8 +538,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpPayloadTraitsInput, context: context)
         type = Types::HttpPayloadTraitsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.blob = params[:blob]
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.blob = params[:blob] unless params[:blob].nil?
         type
       end
     end
@@ -502,8 +549,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpPayloadTraitsOutput, context: context)
         type = Types::HttpPayloadTraitsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.blob = params[:blob]
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.blob = params[:blob] unless params[:blob].nil?
         type
       end
     end
@@ -513,8 +560,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpPayloadTraitsWithMediaTypeInput, context: context)
         type = Types::HttpPayloadTraitsWithMediaTypeInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.blob = params[:blob]
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.blob = params[:blob] unless params[:blob].nil?
         type
       end
     end
@@ -524,8 +571,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpPayloadTraitsWithMediaTypeOutput, context: context)
         type = Types::HttpPayloadTraitsWithMediaTypeOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.blob = params[:blob]
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.blob = params[:blob] unless params[:blob].nil?
         type
       end
     end
@@ -594,7 +641,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpPrefixHeadersInput, context: context)
         type = Types::HttpPrefixHeadersInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type.foo_map = StringMap.build(params[:foo_map], context: "#{context}[:foo_map]") unless params[:foo_map].nil?
         type
       end
@@ -605,7 +652,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpPrefixHeadersOutput, context: context)
         type = Types::HttpPrefixHeadersOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type.foo_map = StringMap.build(params[:foo_map], context: "#{context}[:foo_map]") unless params[:foo_map].nil?
         type
       end
@@ -616,8 +663,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpRequestWithFloatLabelsInput, context: context)
         type = Types::HttpRequestWithFloatLabelsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.float = params[:float]&.to_f
-        type.double = params[:double]&.to_f
+        type.float = params[:float]&.to_f unless params[:float].nil?
+        type.double = params[:double]&.to_f unless params[:double].nil?
         type
       end
     end
@@ -636,8 +683,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpRequestWithGreedyLabelInPathInput, context: context)
         type = Types::HttpRequestWithGreedyLabelInPathInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.baz = params[:baz]
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.baz = params[:baz] unless params[:baz].nil?
         type
       end
     end
@@ -656,13 +703,13 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpRequestWithLabelsAndTimestampFormatInput, context: context)
         type = Types::HttpRequestWithLabelsAndTimestampFormatInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.member_epoch_seconds = params[:member_epoch_seconds]
-        type.member_http_date = params[:member_http_date]
-        type.member_date_time = params[:member_date_time]
-        type.default_format = params[:default_format]
-        type.target_epoch_seconds = params[:target_epoch_seconds]
-        type.target_http_date = params[:target_http_date]
-        type.target_date_time = params[:target_date_time]
+        type.member_epoch_seconds = params[:member_epoch_seconds] unless params[:member_epoch_seconds].nil?
+        type.member_http_date = params[:member_http_date] unless params[:member_http_date].nil?
+        type.member_date_time = params[:member_date_time] unless params[:member_date_time].nil?
+        type.default_format = params[:default_format] unless params[:default_format].nil?
+        type.target_epoch_seconds = params[:target_epoch_seconds] unless params[:target_epoch_seconds].nil?
+        type.target_http_date = params[:target_http_date] unless params[:target_http_date].nil?
+        type.target_date_time = params[:target_date_time] unless params[:target_date_time].nil?
         type
       end
     end
@@ -681,14 +728,14 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpRequestWithLabelsInput, context: context)
         type = Types::HttpRequestWithLabelsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string = params[:string]
-        type.short = params[:short]
-        type.integer = params[:integer]
-        type.long = params[:long]
-        type.float = params[:float]&.to_f
-        type.double = params[:double]&.to_f
-        type.boolean = params[:boolean]
-        type.timestamp = params[:timestamp]
+        type.string = params[:string] unless params[:string].nil?
+        type.short = params[:short] unless params[:short].nil?
+        type.integer = params[:integer] unless params[:integer].nil?
+        type.long = params[:long] unless params[:long].nil?
+        type.float = params[:float]&.to_f unless params[:float].nil?
+        type.double = params[:double]&.to_f unless params[:double].nil?
+        type.boolean = params[:boolean] unless params[:boolean].nil?
+        type.timestamp = params[:timestamp] unless params[:timestamp].nil?
         type
       end
     end
@@ -707,7 +754,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpRequestWithRegexLiteralInput, context: context)
         type = Types::HttpRequestWithRegexLiteralInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.str = params[:str]
+        type.str = params[:str] unless params[:str].nil?
         type
       end
     end
@@ -735,7 +782,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpResponseCodeOutput, context: context)
         type = Types::HttpResponseCodeOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.status = params[:status]
+        type.status = params[:status] unless params[:status].nil?
         type
       end
     end
@@ -745,7 +792,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpStringPayloadInput, context: context)
         type = Types::HttpStringPayloadInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.payload = params[:payload]
+        type.payload = params[:payload] unless params[:payload].nil?
         type
       end
     end
@@ -755,7 +802,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::HttpStringPayloadOutput, context: context)
         type = Types::HttpStringPayloadOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.payload = params[:payload]
+        type.payload = params[:payload] unless params[:payload].nil?
         type
       end
     end
@@ -774,7 +821,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::IgnoreQueryParamsInResponseOutput, context: context)
         type = Types::IgnoreQueryParamsInResponseOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.baz = params[:baz]
+        type.baz = params[:baz] unless params[:baz].nil?
         type
       end
     end
@@ -784,23 +831,23 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::InputAndOutputWithHeadersInput, context: context)
         type = Types::InputAndOutputWithHeadersInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.header_string = params[:header_string]
-        type.header_byte = params[:header_byte]
-        type.header_short = params[:header_short]
-        type.header_integer = params[:header_integer]
-        type.header_long = params[:header_long]
-        type.header_float = params[:header_float]&.to_f
-        type.header_double = params[:header_double]&.to_f
-        type.header_true_bool = params[:header_true_bool]
-        type.header_false_bool = params[:header_false_bool]
+        type.header_string = params[:header_string] unless params[:header_string].nil?
+        type.header_byte = params[:header_byte] unless params[:header_byte].nil?
+        type.header_short = params[:header_short] unless params[:header_short].nil?
+        type.header_integer = params[:header_integer] unless params[:header_integer].nil?
+        type.header_long = params[:header_long] unless params[:header_long].nil?
+        type.header_float = params[:header_float]&.to_f unless params[:header_float].nil?
+        type.header_double = params[:header_double]&.to_f unless params[:header_double].nil?
+        type.header_true_bool = params[:header_true_bool] unless params[:header_true_bool].nil?
+        type.header_false_bool = params[:header_false_bool] unless params[:header_false_bool].nil?
         type.header_string_list = StringList.build(params[:header_string_list], context: "#{context}[:header_string_list]") unless params[:header_string_list].nil?
         type.header_string_set = StringSet.build(params[:header_string_set], context: "#{context}[:header_string_set]") unless params[:header_string_set].nil?
         type.header_integer_list = IntegerList.build(params[:header_integer_list], context: "#{context}[:header_integer_list]") unless params[:header_integer_list].nil?
         type.header_boolean_list = BooleanList.build(params[:header_boolean_list], context: "#{context}[:header_boolean_list]") unless params[:header_boolean_list].nil?
         type.header_timestamp_list = TimestampList.build(params[:header_timestamp_list], context: "#{context}[:header_timestamp_list]") unless params[:header_timestamp_list].nil?
-        type.header_enum = params[:header_enum]
+        type.header_enum = params[:header_enum] unless params[:header_enum].nil?
         type.header_enum_list = FooEnumList.build(params[:header_enum_list], context: "#{context}[:header_enum_list]") unless params[:header_enum_list].nil?
-        type.header_integer_enum = params[:header_integer_enum]
+        type.header_integer_enum = params[:header_integer_enum] unless params[:header_integer_enum].nil?
         type.header_integer_enum_list = IntegerEnumList.build(params[:header_integer_enum_list], context: "#{context}[:header_integer_enum_list]") unless params[:header_integer_enum_list].nil?
         type
       end
@@ -811,23 +858,23 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::InputAndOutputWithHeadersOutput, context: context)
         type = Types::InputAndOutputWithHeadersOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.header_string = params[:header_string]
-        type.header_byte = params[:header_byte]
-        type.header_short = params[:header_short]
-        type.header_integer = params[:header_integer]
-        type.header_long = params[:header_long]
-        type.header_float = params[:header_float]&.to_f
-        type.header_double = params[:header_double]&.to_f
-        type.header_true_bool = params[:header_true_bool]
-        type.header_false_bool = params[:header_false_bool]
+        type.header_string = params[:header_string] unless params[:header_string].nil?
+        type.header_byte = params[:header_byte] unless params[:header_byte].nil?
+        type.header_short = params[:header_short] unless params[:header_short].nil?
+        type.header_integer = params[:header_integer] unless params[:header_integer].nil?
+        type.header_long = params[:header_long] unless params[:header_long].nil?
+        type.header_float = params[:header_float]&.to_f unless params[:header_float].nil?
+        type.header_double = params[:header_double]&.to_f unless params[:header_double].nil?
+        type.header_true_bool = params[:header_true_bool] unless params[:header_true_bool].nil?
+        type.header_false_bool = params[:header_false_bool] unless params[:header_false_bool].nil?
         type.header_string_list = StringList.build(params[:header_string_list], context: "#{context}[:header_string_list]") unless params[:header_string_list].nil?
         type.header_string_set = StringSet.build(params[:header_string_set], context: "#{context}[:header_string_set]") unless params[:header_string_set].nil?
         type.header_integer_list = IntegerList.build(params[:header_integer_list], context: "#{context}[:header_integer_list]") unless params[:header_integer_list].nil?
         type.header_boolean_list = BooleanList.build(params[:header_boolean_list], context: "#{context}[:header_boolean_list]") unless params[:header_boolean_list].nil?
         type.header_timestamp_list = TimestampList.build(params[:header_timestamp_list], context: "#{context}[:header_timestamp_list]") unless params[:header_timestamp_list].nil?
-        type.header_enum = params[:header_enum]
+        type.header_enum = params[:header_enum] unless params[:header_enum].nil?
         type.header_enum_list = FooEnumList.build(params[:header_enum_list], context: "#{context}[:header_enum_list]") unless params[:header_enum_list].nil?
-        type.header_integer_enum = params[:header_integer_enum]
+        type.header_integer_enum = params[:header_integer_enum] unless params[:header_integer_enum].nil?
         type.header_integer_enum_list = IntegerEnumList.build(params[:header_integer_enum_list], context: "#{context}[:header_integer_enum_list]") unless params[:header_integer_enum_list].nil?
         type
       end
@@ -838,7 +885,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -849,7 +896,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -860,7 +907,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -871,7 +918,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -882,7 +929,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -893,7 +940,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::InvalidGreeting, context: context)
         type = Types::InvalidGreeting.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.message = params[:message]
+        type.message = params[:message] unless params[:message].nil?
         type
       end
     end
@@ -903,7 +950,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonBlobsInput, context: context)
         type = Types::JsonBlobsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.data = params[:data]
+        type.data = params[:data] unless params[:data].nil?
         type
       end
     end
@@ -913,7 +960,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonBlobsOutput, context: context)
         type = Types::JsonBlobsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.data = params[:data]
+        type.data = params[:data] unless params[:data].nil?
         type
       end
     end
@@ -923,9 +970,9 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonEnumsInput, context: context)
         type = Types::JsonEnumsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo_enum1 = params[:foo_enum1]
-        type.foo_enum2 = params[:foo_enum2]
-        type.foo_enum3 = params[:foo_enum3]
+        type.foo_enum1 = params[:foo_enum1] unless params[:foo_enum1].nil?
+        type.foo_enum2 = params[:foo_enum2] unless params[:foo_enum2].nil?
+        type.foo_enum3 = params[:foo_enum3] unless params[:foo_enum3].nil?
         type.foo_enum_list = FooEnumList.build(params[:foo_enum_list], context: "#{context}[:foo_enum_list]") unless params[:foo_enum_list].nil?
         type.foo_enum_set = FooEnumSet.build(params[:foo_enum_set], context: "#{context}[:foo_enum_set]") unless params[:foo_enum_set].nil?
         type.foo_enum_map = FooEnumMap.build(params[:foo_enum_map], context: "#{context}[:foo_enum_map]") unless params[:foo_enum_map].nil?
@@ -938,9 +985,9 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonEnumsOutput, context: context)
         type = Types::JsonEnumsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo_enum1 = params[:foo_enum1]
-        type.foo_enum2 = params[:foo_enum2]
-        type.foo_enum3 = params[:foo_enum3]
+        type.foo_enum1 = params[:foo_enum1] unless params[:foo_enum1].nil?
+        type.foo_enum2 = params[:foo_enum2] unless params[:foo_enum2].nil?
+        type.foo_enum3 = params[:foo_enum3] unless params[:foo_enum3].nil?
         type.foo_enum_list = FooEnumList.build(params[:foo_enum_list], context: "#{context}[:foo_enum_list]") unless params[:foo_enum_list].nil?
         type.foo_enum_set = FooEnumSet.build(params[:foo_enum_set], context: "#{context}[:foo_enum_set]") unless params[:foo_enum_set].nil?
         type.foo_enum_map = FooEnumMap.build(params[:foo_enum_map], context: "#{context}[:foo_enum_map]") unless params[:foo_enum_map].nil?
@@ -953,9 +1000,9 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonIntEnumsInput, context: context)
         type = Types::JsonIntEnumsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.integer_enum1 = params[:integer_enum1]
-        type.integer_enum2 = params[:integer_enum2]
-        type.integer_enum3 = params[:integer_enum3]
+        type.integer_enum1 = params[:integer_enum1] unless params[:integer_enum1].nil?
+        type.integer_enum2 = params[:integer_enum2] unless params[:integer_enum2].nil?
+        type.integer_enum3 = params[:integer_enum3] unless params[:integer_enum3].nil?
         type.integer_enum_list = IntegerEnumList.build(params[:integer_enum_list], context: "#{context}[:integer_enum_list]") unless params[:integer_enum_list].nil?
         type.integer_enum_set = IntegerEnumSet.build(params[:integer_enum_set], context: "#{context}[:integer_enum_set]") unless params[:integer_enum_set].nil?
         type.integer_enum_map = IntegerEnumMap.build(params[:integer_enum_map], context: "#{context}[:integer_enum_map]") unless params[:integer_enum_map].nil?
@@ -968,9 +1015,9 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonIntEnumsOutput, context: context)
         type = Types::JsonIntEnumsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.integer_enum1 = params[:integer_enum1]
-        type.integer_enum2 = params[:integer_enum2]
-        type.integer_enum3 = params[:integer_enum3]
+        type.integer_enum1 = params[:integer_enum1] unless params[:integer_enum1].nil?
+        type.integer_enum2 = params[:integer_enum2] unless params[:integer_enum2].nil?
+        type.integer_enum3 = params[:integer_enum3] unless params[:integer_enum3].nil?
         type.integer_enum_list = IntegerEnumList.build(params[:integer_enum_list], context: "#{context}[:integer_enum_list]") unless params[:integer_enum_list].nil?
         type.integer_enum_set = IntegerEnumSet.build(params[:integer_enum_set], context: "#{context}[:integer_enum_set]") unless params[:integer_enum_set].nil?
         type.integer_enum_map = IntegerEnumMap.build(params[:integer_enum_map], context: "#{context}[:integer_enum_map]") unless params[:integer_enum_map].nil?
@@ -1047,13 +1094,13 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonTimestampsInput, context: context)
         type = Types::JsonTimestampsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.normal = params[:normal]
-        type.date_time = params[:date_time]
-        type.date_time_on_target = params[:date_time_on_target]
-        type.epoch_seconds = params[:epoch_seconds]
-        type.epoch_seconds_on_target = params[:epoch_seconds_on_target]
-        type.http_date = params[:http_date]
-        type.http_date_on_target = params[:http_date_on_target]
+        type.normal = params[:normal] unless params[:normal].nil?
+        type.date_time = params[:date_time] unless params[:date_time].nil?
+        type.date_time_on_target = params[:date_time_on_target] unless params[:date_time_on_target].nil?
+        type.epoch_seconds = params[:epoch_seconds] unless params[:epoch_seconds].nil?
+        type.epoch_seconds_on_target = params[:epoch_seconds_on_target] unless params[:epoch_seconds_on_target].nil?
+        type.http_date = params[:http_date] unless params[:http_date].nil?
+        type.http_date_on_target = params[:http_date_on_target] unless params[:http_date_on_target].nil?
         type
       end
     end
@@ -1063,13 +1110,13 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::JsonTimestampsOutput, context: context)
         type = Types::JsonTimestampsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.normal = params[:normal]
-        type.date_time = params[:date_time]
-        type.date_time_on_target = params[:date_time_on_target]
-        type.epoch_seconds = params[:epoch_seconds]
-        type.epoch_seconds_on_target = params[:epoch_seconds_on_target]
-        type.http_date = params[:http_date]
-        type.http_date_on_target = params[:http_date_on_target]
+        type.normal = params[:normal] unless params[:normal].nil?
+        type.date_time = params[:date_time] unless params[:date_time].nil?
+        type.date_time_on_target = params[:date_time_on_target] unless params[:date_time_on_target].nil?
+        type.epoch_seconds = params[:epoch_seconds] unless params[:epoch_seconds].nil?
+        type.epoch_seconds_on_target = params[:epoch_seconds_on_target] unless params[:epoch_seconds_on_target].nil?
+        type.http_date = params[:http_date] unless params[:http_date].nil?
+        type.http_date_on_target = params[:http_date_on_target] unless params[:http_date_on_target].nil?
         type
       end
     end
@@ -1099,7 +1146,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::MediaTypeHeaderInput, context: context)
         type = Types::MediaTypeHeaderInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.json = params[:json]
+        type.json = params[:json] unless params[:json].nil?
         type
       end
     end
@@ -1109,7 +1156,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::MediaTypeHeaderOutput, context: context)
         type = Types::MediaTypeHeaderOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.json = params[:json]
+        type.json = params[:json] unless params[:json].nil?
         type
       end
     end
@@ -1176,8 +1223,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::NestedPayload, context: context)
         type = Types::NestedPayload.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.greeting = params[:greeting]
-        type.name = params[:name]
+        type.greeting = params[:greeting] unless params[:greeting].nil?
+        type.name = params[:name] unless params[:name].nil?
         type
       end
     end
@@ -1234,8 +1281,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::NullAndEmptyHeadersClientInput, context: context)
         type = Types::NullAndEmptyHeadersClientInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.a = params[:a]
-        type.b = params[:b]
+        type.a = params[:a] unless params[:a].nil?
+        type.b = params[:b] unless params[:b].nil?
         type.c = StringList.build(params[:c], context: "#{context}[:c]") unless params[:c].nil?
         type
       end
@@ -1246,8 +1293,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::NullAndEmptyHeadersClientOutput, context: context)
         type = Types::NullAndEmptyHeadersClientOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.a = params[:a]
-        type.b = params[:b]
+        type.a = params[:a] unless params[:a].nil?
+        type.b = params[:b] unless params[:b].nil?
         type.c = StringList.build(params[:c], context: "#{context}[:c]") unless params[:c].nil?
         type
       end
@@ -1258,8 +1305,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::NullAndEmptyHeadersServerInput, context: context)
         type = Types::NullAndEmptyHeadersServerInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.a = params[:a]
-        type.b = params[:b]
+        type.a = params[:a] unless params[:a].nil?
+        type.b = params[:b] unless params[:b].nil?
         type.c = StringList.build(params[:c], context: "#{context}[:c]") unless params[:c].nil?
         type
       end
@@ -1270,8 +1317,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::NullAndEmptyHeadersServerOutput, context: context)
         type = Types::NullAndEmptyHeadersServerOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.a = params[:a]
-        type.b = params[:b]
+        type.a = params[:a] unless params[:a].nil?
+        type.b = params[:b] unless params[:b].nil?
         type.c = StringList.build(params[:c], context: "#{context}[:c]") unless params[:c].nil?
         type
       end
@@ -1282,8 +1329,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::OmitsNullSerializesEmptyStringInput, context: context)
         type = Types::OmitsNullSerializesEmptyStringInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.null_value = params[:null_value]
-        type.empty_string = params[:empty_string]
+        type.null_value = params[:null_value] unless params[:null_value].nil?
+        type.empty_string = params[:empty_string] unless params[:empty_string].nil?
         type
       end
     end
@@ -1322,12 +1369,62 @@ module RailsJson
       end
     end
 
+    class OperationWithDefaultsInput
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::OperationWithDefaultsInput, context: context)
+        type = Types::OperationWithDefaultsInput.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.defaults = Defaults.build(params[:defaults], context: "#{context}[:defaults]") unless params[:defaults].nil?
+        type.client_optional_defaults = ClientOptionalDefaults.build(params[:client_optional_defaults], context: "#{context}[:client_optional_defaults]") unless params[:client_optional_defaults].nil?
+        type.top_level_default = params[:top_level_default] unless params[:top_level_default].nil?
+        type.other_top_level_default = params[:other_top_level_default] unless params[:other_top_level_default].nil?
+        type
+      end
+    end
+
+    class OperationWithDefaultsOutput
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::OperationWithDefaultsOutput, context: context)
+        type = Types::OperationWithDefaultsOutput.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.default_string = params[:default_string] unless params[:default_string].nil?
+        type.default_boolean = params[:default_boolean] unless params[:default_boolean].nil?
+        type.default_list = TestStringList.build(params[:default_list], context: "#{context}[:default_list]") unless params[:default_list].nil?
+        type.default_document_map = params[:default_document_map] unless params[:default_document_map].nil?
+        type.default_document_string = params[:default_document_string] unless params[:default_document_string].nil?
+        type.default_document_boolean = params[:default_document_boolean] unless params[:default_document_boolean].nil?
+        type.default_document_list = params[:default_document_list] unless params[:default_document_list].nil?
+        type.default_null_document = params[:default_null_document] unless params[:default_null_document].nil?
+        type.default_timestamp = params[:default_timestamp] unless params[:default_timestamp].nil?
+        type.default_blob = params[:default_blob] unless params[:default_blob].nil?
+        type.default_byte = params[:default_byte] unless params[:default_byte].nil?
+        type.default_short = params[:default_short] unless params[:default_short].nil?
+        type.default_integer = params[:default_integer] unless params[:default_integer].nil?
+        type.default_long = params[:default_long] unless params[:default_long].nil?
+        type.default_float = params[:default_float]&.to_f unless params[:default_float].nil?
+        type.default_double = params[:default_double]&.to_f unless params[:default_double].nil?
+        type.default_map = TestStringMap.build(params[:default_map], context: "#{context}[:default_map]") unless params[:default_map].nil?
+        type.default_enum = params[:default_enum] unless params[:default_enum].nil?
+        type.default_int_enum = params[:default_int_enum] unless params[:default_int_enum].nil?
+        type.empty_string = params[:empty_string] unless params[:empty_string].nil?
+        type.false_boolean = params[:false_boolean] unless params[:false_boolean].nil?
+        type.empty_blob = params[:empty_blob] unless params[:empty_blob].nil?
+        type.zero_byte = params[:zero_byte] unless params[:zero_byte].nil?
+        type.zero_short = params[:zero_short] unless params[:zero_short].nil?
+        type.zero_integer = params[:zero_integer] unless params[:zero_integer].nil?
+        type.zero_long = params[:zero_long] unless params[:zero_long].nil?
+        type.zero_float = params[:zero_float]&.to_f unless params[:zero_float].nil?
+        type.zero_double = params[:zero_double]&.to_f unless params[:zero_double].nil?
+        type
+      end
+    end
+
     class PayloadConfig
       def self.build(params, context:)
         Hearth::Validator.validate_types!(params, ::Hash, Types::PayloadConfig, context: context)
         type = Types::PayloadConfig.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.data = params[:data]
+        type.data = params[:data] unless params[:data].nil?
         type
       end
     end
@@ -1398,8 +1495,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::PutWithContentEncodingInput, context: context)
         type = Types::PutWithContentEncodingInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.encoding = params[:encoding]
-        type.data = params[:data]
+        type.encoding = params[:encoding] unless params[:encoding].nil?
+        type.data = params[:data] unless params[:data].nil?
         type
       end
     end
@@ -1437,7 +1534,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::QueryParamsAsStringListMapInput, context: context)
         type = Types::QueryParamsAsStringListMapInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.qux = params[:qux]
+        type.qux = params[:qux] unless params[:qux].nil?
         type.foo = StringListMap.build(params[:foo], context: "#{context}[:foo]") unless params[:foo].nil?
         type
       end
@@ -1457,7 +1554,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::QueryPrecedenceInput, context: context)
         type = Types::QueryPrecedenceInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type.baz = StringMap.build(params[:baz], context: "#{context}[:baz]") unless params[:baz].nil?
         type
       end
@@ -1487,7 +1584,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::RecursiveShapesInputOutputNested1, context: context)
         type = Types::RecursiveShapesInputOutputNested1.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         type.nested = RecursiveShapesInputOutputNested2.build(params[:nested], context: "#{context}[:nested]") unless params[:nested].nil?
         type
       end
@@ -1498,7 +1595,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::RecursiveShapesInputOutputNested2, context: context)
         type = Types::RecursiveShapesInputOutputNested2.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.bar = params[:bar]
+        type.bar = params[:bar] unless params[:bar].nil?
         type.recursive_member = RecursiveShapesInputOutputNested1.build(params[:recursive_member], context: "#{context}[:recursive_member]") unless params[:recursive_member].nil?
         type
       end
@@ -1519,16 +1616,16 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::SimpleScalarPropertiesInput, context: context)
         type = Types::SimpleScalarPropertiesInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.string_value = params[:string_value]
-        type.true_boolean_value = params[:true_boolean_value]
-        type.false_boolean_value = params[:false_boolean_value]
-        type.byte_value = params[:byte_value]
-        type.short_value = params[:short_value]
-        type.integer_value = params[:integer_value]
-        type.long_value = params[:long_value]
-        type.float_value = params[:float_value]&.to_f
-        type.double_value = params[:double_value]&.to_f
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.string_value = params[:string_value] unless params[:string_value].nil?
+        type.true_boolean_value = params[:true_boolean_value] unless params[:true_boolean_value].nil?
+        type.false_boolean_value = params[:false_boolean_value] unless params[:false_boolean_value].nil?
+        type.byte_value = params[:byte_value] unless params[:byte_value].nil?
+        type.short_value = params[:short_value] unless params[:short_value].nil?
+        type.integer_value = params[:integer_value] unless params[:integer_value].nil?
+        type.long_value = params[:long_value] unless params[:long_value].nil?
+        type.float_value = params[:float_value]&.to_f unless params[:float_value].nil?
+        type.double_value = params[:double_value]&.to_f unless params[:double_value].nil?
         type
       end
     end
@@ -1538,16 +1635,16 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::SimpleScalarPropertiesOutput, context: context)
         type = Types::SimpleScalarPropertiesOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
-        type.string_value = params[:string_value]
-        type.true_boolean_value = params[:true_boolean_value]
-        type.false_boolean_value = params[:false_boolean_value]
-        type.byte_value = params[:byte_value]
-        type.short_value = params[:short_value]
-        type.integer_value = params[:integer_value]
-        type.long_value = params[:long_value]
-        type.float_value = params[:float_value]&.to_f
-        type.double_value = params[:double_value]&.to_f
+        type.foo = params[:foo] unless params[:foo].nil?
+        type.string_value = params[:string_value] unless params[:string_value].nil?
+        type.true_boolean_value = params[:true_boolean_value] unless params[:true_boolean_value].nil?
+        type.false_boolean_value = params[:false_boolean_value] unless params[:false_boolean_value].nil?
+        type.byte_value = params[:byte_value] unless params[:byte_value].nil?
+        type.short_value = params[:short_value] unless params[:short_value].nil?
+        type.integer_value = params[:integer_value] unless params[:integer_value].nil?
+        type.long_value = params[:long_value] unless params[:long_value].nil?
+        type.float_value = params[:float_value]&.to_f unless params[:float_value].nil?
+        type.double_value = params[:double_value]&.to_f unless params[:double_value].nil?
         type
       end
     end
@@ -1671,7 +1768,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::StreamingTraitsInput, context: context)
         type = Types::StreamingTraitsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         io = params[:blob] || StringIO.new
         unless io.respond_to?(:read) || io.respond_to?(:readpartial)
           io = StringIO.new(io)
@@ -1686,7 +1783,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::StreamingTraitsOutput, context: context)
         type = Types::StreamingTraitsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         io = params[:blob] || StringIO.new
         unless io.respond_to?(:read) || io.respond_to?(:readpartial)
           io = StringIO.new(io)
@@ -1701,7 +1798,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::StreamingTraitsRequireLengthInput, context: context)
         type = Types::StreamingTraitsRequireLengthInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         io = params[:blob] || StringIO.new
         unless io.respond_to?(:read) || io.respond_to?(:readpartial)
           io = StringIO.new(io)
@@ -1725,7 +1822,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::StreamingTraitsWithMediaTypeInput, context: context)
         type = Types::StreamingTraitsWithMediaTypeInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         io = params[:blob] || StringIO.new
         unless io.respond_to?(:read) || io.respond_to?(:readpartial)
           io = StringIO.new(io)
@@ -1740,7 +1837,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::StreamingTraitsWithMediaTypeOutput, context: context)
         type = Types::StreamingTraitsWithMediaTypeOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.foo = params[:foo]
+        type.foo = params[:foo] unless params[:foo].nil?
         io = params[:blob] || StringIO.new
         unless io.respond_to?(:read) || io.respond_to?(:readpartial)
           io = StringIO.new(io)
@@ -1755,7 +1852,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -1777,7 +1874,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -1788,7 +1885,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -1810,8 +1907,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::StructureListMember, context: context)
         type = Types::StructureListMember.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.a = params[:a]
-        type.b = params[:b]
+        type.a = params[:a] unless params[:a].nil?
+        type.b = params[:b] unless params[:b].nil?
         type
       end
     end
@@ -1821,7 +1918,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestBodyStructureInput, context: context)
         type = Types::TestBodyStructureInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.test_id = params[:test_id]
+        type.test_id = params[:test_id] unless params[:test_id].nil?
         type.test_config = TestConfig.build(params[:test_config], context: "#{context}[:test_config]") unless params[:test_config].nil?
         type
       end
@@ -1832,7 +1929,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestBodyStructureOutput, context: context)
         type = Types::TestBodyStructureOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.test_id = params[:test_id]
+        type.test_id = params[:test_id] unless params[:test_id].nil?
         type.test_config = TestConfig.build(params[:test_config], context: "#{context}[:test_config]") unless params[:test_config].nil?
         type
       end
@@ -1843,7 +1940,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestConfig, context: context)
         type = Types::TestConfig.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.timeout = params[:timeout]
+        type.timeout = params[:timeout] unless params[:timeout].nil?
         type
       end
     end
@@ -1853,7 +1950,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestNoPayloadInput, context: context)
         type = Types::TestNoPayloadInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.test_id = params[:test_id]
+        type.test_id = params[:test_id] unless params[:test_id].nil?
         type
       end
     end
@@ -1863,7 +1960,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestNoPayloadOutput, context: context)
         type = Types::TestNoPayloadOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.test_id = params[:test_id]
+        type.test_id = params[:test_id] unless params[:test_id].nil?
         type
       end
     end
@@ -1873,8 +1970,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestPayloadBlobInput, context: context)
         type = Types::TestPayloadBlobInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.content_type = params[:content_type]
-        type.data = params[:data]
+        type.content_type = params[:content_type] unless params[:content_type].nil?
+        type.data = params[:data] unless params[:data].nil?
         type
       end
     end
@@ -1884,8 +1981,8 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestPayloadBlobOutput, context: context)
         type = Types::TestPayloadBlobOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.content_type = params[:content_type]
-        type.data = params[:data]
+        type.content_type = params[:content_type] unless params[:content_type].nil?
+        type.data = params[:data] unless params[:data].nil?
         type
       end
     end
@@ -1895,7 +1992,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestPayloadStructureInput, context: context)
         type = Types::TestPayloadStructureInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.test_id = params[:test_id]
+        type.test_id = params[:test_id] unless params[:test_id].nil?
         type.payload_config = PayloadConfig.build(params[:payload_config], context: "#{context}[:payload_config]") unless params[:payload_config].nil?
         type
       end
@@ -1906,9 +2003,31 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TestPayloadStructureOutput, context: context)
         type = Types::TestPayloadStructureOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.test_id = params[:test_id]
+        type.test_id = params[:test_id] unless params[:test_id].nil?
         type.payload_config = PayloadConfig.build(params[:payload_config], context: "#{context}[:payload_config]") unless params[:payload_config].nil?
         type
+      end
+    end
+
+    class TestStringList
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Array, context: context)
+        data = []
+        params.each do |element|
+          data << element unless element.nil?
+        end
+        data
+      end
+    end
+
+    class TestStringMap
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, context: context)
+        data = {}
+        params.each do |key, value|
+          data[key] = value unless value.nil?
+        end
+        data
       end
     end
 
@@ -1917,13 +2036,13 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TimestampFormatHeadersInput, context: context)
         type = Types::TimestampFormatHeadersInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.member_epoch_seconds = params[:member_epoch_seconds]
-        type.member_http_date = params[:member_http_date]
-        type.member_date_time = params[:member_date_time]
-        type.default_format = params[:default_format]
-        type.target_epoch_seconds = params[:target_epoch_seconds]
-        type.target_http_date = params[:target_http_date]
-        type.target_date_time = params[:target_date_time]
+        type.member_epoch_seconds = params[:member_epoch_seconds] unless params[:member_epoch_seconds].nil?
+        type.member_http_date = params[:member_http_date] unless params[:member_http_date].nil?
+        type.member_date_time = params[:member_date_time] unless params[:member_date_time].nil?
+        type.default_format = params[:default_format] unless params[:default_format].nil?
+        type.target_epoch_seconds = params[:target_epoch_seconds] unless params[:target_epoch_seconds].nil?
+        type.target_http_date = params[:target_http_date] unless params[:target_http_date].nil?
+        type.target_date_time = params[:target_date_time] unless params[:target_date_time].nil?
         type
       end
     end
@@ -1933,13 +2052,13 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::TimestampFormatHeadersOutput, context: context)
         type = Types::TimestampFormatHeadersOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.member_epoch_seconds = params[:member_epoch_seconds]
-        type.member_http_date = params[:member_http_date]
-        type.member_date_time = params[:member_date_time]
-        type.default_format = params[:default_format]
-        type.target_epoch_seconds = params[:target_epoch_seconds]
-        type.target_http_date = params[:target_http_date]
-        type.target_date_time = params[:target_date_time]
+        type.member_epoch_seconds = params[:member_epoch_seconds] unless params[:member_epoch_seconds].nil?
+        type.member_http_date = params[:member_http_date] unless params[:member_http_date].nil?
+        type.member_date_time = params[:member_date_time] unless params[:member_date_time].nil?
+        type.default_format = params[:default_format] unless params[:default_format].nil?
+        type.target_epoch_seconds = params[:target_epoch_seconds] unless params[:target_epoch_seconds].nil?
+        type.target_http_date = params[:target_http_date] unless params[:target_http_date].nil?
+        type.target_date_time = params[:target_date_time] unless params[:target_date_time].nil?
         type
       end
     end
@@ -1949,7 +2068,7 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -245,6 +245,40 @@ module RailsJson
       end
     end
 
+    class Dialog
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::Dialog, context: context)
+        type = Types::Dialog.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.language = params[:language] unless params[:language].nil?
+        type.greeting = params[:greeting] unless params[:greeting].nil?
+        type.farewell = Farewell.build(params[:farewell], context: "#{context}[:farewell]") unless params[:farewell].nil?
+        type
+      end
+    end
+
+    class DialogList
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Array, context: context)
+        data = []
+        params.each_with_index do |element, index|
+          data << Dialog.build(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+        data
+      end
+    end
+
+    class DialogMap
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, context: context)
+        data = {}
+        params.each do |key, value|
+          data[key] = Dialog.build(value, context: "#{context}[:#{key}]") unless value.nil?
+        end
+        data
+      end
+    end
+
     class DocumentTypeAsMapValueInput
       def self.build(params, context:)
         Hearth::Validator.validate_types!(params, ::Hash, Types::DocumentTypeAsMapValueInput, context: context)
@@ -380,6 +414,16 @@ module RailsJson
         Hearth::Validator.validate_types!(params, ::Hash, Types::EndpointWithHostLabelOperationOutput, context: context)
         type = Types::EndpointWithHostLabelOperationOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type
+      end
+    end
+
+    class Farewell
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::Farewell, context: context)
+        type = Types::Farewell.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.phrase = params[:phrase] unless params[:phrase].nil?
         type
       end
     end
@@ -1419,6 +1463,28 @@ module RailsJson
       end
     end
 
+    class OperationWithNestedStructureInput
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::OperationWithNestedStructureInput, context: context)
+        type = Types::OperationWithNestedStructureInput.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.top_level = TopLevel.build(params[:top_level], context: "#{context}[:top_level]") unless params[:top_level].nil?
+        type
+      end
+    end
+
+    class OperationWithNestedStructureOutput
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::OperationWithNestedStructureOutput, context: context)
+        type = Types::OperationWithNestedStructureOutput.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.dialog = Dialog.build(params[:dialog], context: "#{context}[:dialog]") unless params[:dialog].nil?
+        type.dialog_list = DialogList.build(params[:dialog_list], context: "#{context}[:dialog_list]") unless params[:dialog_list].nil?
+        type.dialog_map = DialogMap.build(params[:dialog_map], context: "#{context}[:dialog_map]") unless params[:dialog_map].nil?
+        type
+      end
+    end
+
     class PayloadConfig
       def self.build(params, context:)
         Hearth::Validator.validate_types!(params, ::Hash, Types::PayloadConfig, context: context)
@@ -2071,6 +2137,18 @@ module RailsJson
           data << element unless element.nil?
         end
         data
+      end
+    end
+
+    class TopLevel
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::TopLevel, context: context)
+        type = Types::TopLevel.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.dialog = Dialog.build(params[:dialog], context: "#{context}[:dialog]") unless params[:dialog].nil?
+        type.dialog_list = DialogList.build(params[:dialog_list], context: "#{context}[:dialog_list]") unless params[:dialog_list].nil?
+        type.dialog_map = DialogMap.build(params[:dialog_map], context: "#{context}[:dialog_map]") unless params[:dialog_map].nil?
+        type
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -677,6 +677,42 @@ module RailsJson
       end
     end
 
+    class OperationWithDefaults
+      def self.parse(http_resp)
+        data = Types::OperationWithDefaultsOutput.new
+        map = Hearth::JSON.parse(http_resp.body.read)
+        data.default_string = map['default_string'] unless map['default_string'].nil?
+        data.default_boolean = map['default_boolean'] unless map['default_boolean'].nil?
+        data.default_list = Parsers::TestStringList.parse(map['default_list']) unless map['default_list'].nil?
+        data.default_document_map = map['default_document_map'] unless map['default_document_map'].nil?
+        data.default_document_string = map['default_document_string'] unless map['default_document_string'].nil?
+        data.default_document_boolean = map['default_document_boolean'] unless map['default_document_boolean'].nil?
+        data.default_document_list = map['default_document_list'] unless map['default_document_list'].nil?
+        data.default_null_document = map['default_null_document'] unless map['default_null_document'].nil?
+        data.default_timestamp = Time.parse(map['default_timestamp']) if map['default_timestamp']
+        data.default_blob = ::Base64::decode64(map['default_blob']) unless map['default_blob'].nil?
+        data.default_byte = map['default_byte'] unless map['default_byte'].nil?
+        data.default_short = map['default_short'] unless map['default_short'].nil?
+        data.default_integer = map['default_integer'] unless map['default_integer'].nil?
+        data.default_long = map['default_long'] unless map['default_long'].nil?
+        data.default_float = Hearth::NumberHelper.deserialize(map['default_float']) unless map['default_float'].nil?
+        data.default_double = Hearth::NumberHelper.deserialize(map['default_double']) unless map['default_double'].nil?
+        data.default_map = Parsers::TestStringMap.parse(map['default_map']) unless map['default_map'].nil?
+        data.default_enum = map['default_enum'] unless map['default_enum'].nil?
+        data.default_int_enum = map['default_int_enum'] unless map['default_int_enum'].nil?
+        data.empty_string = map['empty_string'] unless map['empty_string'].nil?
+        data.false_boolean = map['false_boolean'] unless map['false_boolean'].nil?
+        data.empty_blob = ::Base64::decode64(map['empty_blob']) unless map['empty_blob'].nil?
+        data.zero_byte = map['zero_byte'] unless map['zero_byte'].nil?
+        data.zero_short = map['zero_short'] unless map['zero_short'].nil?
+        data.zero_integer = map['zero_integer'] unless map['zero_integer'].nil?
+        data.zero_long = map['zero_long'] unless map['zero_long'].nil?
+        data.zero_float = Hearth::NumberHelper.deserialize(map['zero_float']) unless map['zero_float'].nil?
+        data.zero_double = Hearth::NumberHelper.deserialize(map['zero_double']) unless map['zero_double'].nil?
+        data
+      end
+    end
+
     class PayloadConfig
       def self.parse(map)
         data = Types::PayloadConfig.new
@@ -981,6 +1017,24 @@ module RailsJson
         data.test_id = http_resp.headers['x-amz-test-id']
         map = Hearth::JSON.parse(http_resp.body.read)
         data.payload_config = Parsers::PayloadConfig.parse(map)
+        data
+      end
+    end
+
+    class TestStringList
+      def self.parse(list)
+        list.map do |value|
+          value unless value.nil?
+        end
+      end
+    end
+
+    class TestStringMap
+      def self.parse(map)
+        data = {}
+        map.map do |key, value|
+          data[key] = value unless value.nil?
+        end
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -121,6 +121,34 @@ module RailsJson
       end
     end
 
+    class Dialog
+      def self.parse(map)
+        data = Types::Dialog.new
+        data.language = map['language'] unless map['language'].nil?
+        data.greeting = map['greeting'] unless map['greeting'].nil?
+        data.farewell = Parsers::Farewell.parse(map['farewell']) unless map['farewell'].nil?
+        data
+      end
+    end
+
+    class DialogList
+      def self.parse(list)
+        list.map do |value|
+          Parsers::Dialog.parse(value) unless value.nil?
+        end
+      end
+    end
+
+    class DialogMap
+      def self.parse(map)
+        data = {}
+        map.map do |key, value|
+          data[key] = Parsers::Dialog.parse(value) unless value.nil?
+        end
+        data
+      end
+    end
+
     class DocumentType
       def self.parse(http_resp)
         data = Types::DocumentTypeOutput.new
@@ -176,6 +204,14 @@ module RailsJson
     class EndpointWithHostLabelOperation
       def self.parse(http_resp)
         data = Types::EndpointWithHostLabelOperationOutput.new
+        data
+      end
+    end
+
+    class Farewell
+      def self.parse(map)
+        data = Types::Farewell.new
+        data.phrase = map['phrase'] unless map['phrase'].nil?
         data
       end
     end
@@ -709,6 +745,17 @@ module RailsJson
         data.zero_long = map['zero_long'] unless map['zero_long'].nil?
         data.zero_float = Hearth::NumberHelper.deserialize(map['zero_float']) unless map['zero_float'].nil?
         data.zero_double = Hearth::NumberHelper.deserialize(map['zero_double']) unless map['zero_double'].nil?
+        data
+      end
+    end
+
+    class OperationWithNestedStructure
+      def self.parse(http_resp)
+        data = Types::OperationWithNestedStructureOutput.new
+        map = Hearth::JSON.parse(http_resp.body.read)
+        data.dialog = Parsers::Dialog.parse(map['dialog']) unless map['dialog'].nil?
+        data.dialog_list = Parsers::DialogList.parse(map['dialog_list']) unless map['dialog_list'].nil?
+        data.dialog_map = Parsers::DialogMap.parse(map['dialog_map']) unless map['dialog_map'].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1598,6 +1598,84 @@ module RailsJson
       end
     end
 
+    class OperationWithDefaults
+      def self.build(params, context:)
+        Params::OperationWithDefaultsOutput.build(params, context: context)
+      end
+
+      def self.validate!(output, context:)
+        Validators::OperationWithDefaultsOutput.validate!(output, context: context)
+      end
+
+      def self.default(visited = [])
+        {
+          default_string: 'default_string',
+          default_boolean: false,
+          default_list: TestStringList.default(visited),
+          default_document_map: nil,
+          default_document_string: nil,
+          default_document_boolean: nil,
+          default_document_list: nil,
+          default_null_document: nil,
+          default_timestamp: Time.now,
+          default_blob: 'default_blob',
+          default_byte: 1,
+          default_short: 1,
+          default_integer: 1,
+          default_long: 1,
+          default_float: 1.0,
+          default_double: 1.0,
+          default_map: TestStringMap.default(visited),
+          default_enum: 'default_enum',
+          default_int_enum: 1,
+          empty_string: 'empty_string',
+          false_boolean: false,
+          empty_blob: 'empty_blob',
+          zero_byte: 1,
+          zero_short: 1,
+          zero_integer: 1,
+          zero_long: 1,
+          zero_float: 1.0,
+          zero_double: 1.0,
+        }
+      end
+
+      def self.stub(http_resp, stub:)
+        data = {}
+        http_resp.status = 200
+        http_resp.headers['Content-Type'] = 'application/json'
+        data[:default_string] = stub[:default_string] unless stub[:default_string].nil?
+        data[:default_boolean] = stub[:default_boolean] unless stub[:default_boolean].nil?
+        data[:default_list] = Stubs::TestStringList.stub(stub[:default_list]) unless stub[:default_list].nil?
+        data[:default_document_map] = stub[:default_document_map] unless stub[:default_document_map].nil?
+        data[:default_document_string] = stub[:default_document_string] unless stub[:default_document_string].nil?
+        data[:default_document_boolean] = stub[:default_document_boolean] unless stub[:default_document_boolean].nil?
+        data[:default_document_list] = stub[:default_document_list] unless stub[:default_document_list].nil?
+        data[:default_null_document] = stub[:default_null_document] unless stub[:default_null_document].nil?
+        data[:default_timestamp] = Hearth::TimeHelper.to_date_time(stub[:default_timestamp]) unless stub[:default_timestamp].nil?
+        data[:default_blob] = ::Base64::encode64(stub[:default_blob]) unless stub[:default_blob].nil?
+        data[:default_byte] = stub[:default_byte] unless stub[:default_byte].nil?
+        data[:default_short] = stub[:default_short] unless stub[:default_short].nil?
+        data[:default_integer] = stub[:default_integer] unless stub[:default_integer].nil?
+        data[:default_long] = stub[:default_long] unless stub[:default_long].nil?
+        data[:default_float] = Hearth::NumberHelper.serialize(stub[:default_float])
+        data[:default_double] = Hearth::NumberHelper.serialize(stub[:default_double])
+        data[:default_map] = Stubs::TestStringMap.stub(stub[:default_map]) unless stub[:default_map].nil?
+        data[:default_enum] = stub[:default_enum] unless stub[:default_enum].nil?
+        data[:default_int_enum] = stub[:default_int_enum] unless stub[:default_int_enum].nil?
+        data[:empty_string] = stub[:empty_string] unless stub[:empty_string].nil?
+        data[:false_boolean] = stub[:false_boolean] unless stub[:false_boolean].nil?
+        data[:empty_blob] = ::Base64::encode64(stub[:empty_blob]) unless stub[:empty_blob].nil?
+        data[:zero_byte] = stub[:zero_byte] unless stub[:zero_byte].nil?
+        data[:zero_short] = stub[:zero_short] unless stub[:zero_short].nil?
+        data[:zero_integer] = stub[:zero_integer] unless stub[:zero_integer].nil?
+        data[:zero_long] = stub[:zero_long] unless stub[:zero_long].nil?
+        data[:zero_float] = Hearth::NumberHelper.serialize(stub[:zero_float])
+        data[:zero_double] = Hearth::NumberHelper.serialize(stub[:zero_double])
+        http_resp.body.write(Hearth::JSON.dump(data))
+      end
+    end
+
     class PayloadConfig
       def self.default(visited = [])
         return nil if visited.include?('PayloadConfig')
@@ -2316,6 +2394,44 @@ module RailsJson
         http_resp.headers['Content-Type'] = 'application/json'
         data = Stubs::PayloadConfig.stub(stub[:payload_config]) unless stub[:payload_config].nil?
         http_resp.body.write(Hearth::JSON.dump(data))
+      end
+    end
+
+    class TestStringList
+      def self.default(visited = [])
+        return nil if visited.include?('TestStringList')
+        visited = visited + ['TestStringList']
+        [
+          'member'
+        ]
+      end
+
+      def self.stub(stub)
+        stub ||= []
+        data = []
+        stub.each do |element|
+          data << element unless element.nil?
+        end
+        data
+      end
+    end
+
+    class TestStringMap
+      def self.default(visited = [])
+        return nil if visited.include?('TestStringMap')
+        visited = visited + ['TestStringMap']
+        {
+          key: 'value'
+        }
+      end
+
+      def self.stub(stub)
+        stub ||= {}
+        data = {}
+        stub.each do |key, value|
+          data[key] = value unless value.nil?
+        end
+        data
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -257,6 +257,65 @@ module RailsJson
       end
     end
 
+    class Dialog
+      def self.default(visited = [])
+        return nil if visited.include?('Dialog')
+        visited = visited + ['Dialog']
+        {
+          language: 'language',
+          greeting: 'greeting',
+          farewell: Farewell.default(visited),
+        }
+      end
+
+      def self.stub(stub)
+        stub ||= Types::Dialog.new
+        data = {}
+        data[:language] = stub[:language] unless stub[:language].nil?
+        data[:greeting] = stub[:greeting] unless stub[:greeting].nil?
+        data[:farewell] = Stubs::Farewell.stub(stub[:farewell]) unless stub[:farewell].nil?
+        data
+      end
+    end
+
+    class DialogList
+      def self.default(visited = [])
+        return nil if visited.include?('DialogList')
+        visited = visited + ['DialogList']
+        [
+          Dialog.default(visited)
+        ]
+      end
+
+      def self.stub(stub)
+        stub ||= []
+        data = []
+        stub.each do |element|
+          data << Stubs::Dialog.stub(element) unless element.nil?
+        end
+        data
+      end
+    end
+
+    class DialogMap
+      def self.default(visited = [])
+        return nil if visited.include?('DialogMap')
+        visited = visited + ['DialogMap']
+        {
+          key: Dialog.default(visited)
+        }
+      end
+
+      def self.stub(stub)
+        stub ||= {}
+        data = {}
+        stub.each do |key, value|
+          data[key] = Stubs::Dialog.stub(value) unless value.nil?
+        end
+        data
+      end
+    end
+
     class Document
       def self.default(visited = [])
         return nil if visited.include?('Document')
@@ -418,6 +477,23 @@ module RailsJson
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
+      end
+    end
+
+    class Farewell
+      def self.default(visited = [])
+        return nil if visited.include?('Farewell')
+        visited = visited + ['Farewell']
+        {
+          phrase: 'phrase',
+        }
+      end
+
+      def self.stub(stub)
+        stub ||= Types::Farewell.new
+        data = {}
+        data[:phrase] = stub[:phrase] unless stub[:phrase].nil?
+        data
       end
     end
 
@@ -1672,6 +1748,34 @@ module RailsJson
         data[:zero_long] = stub[:zero_long] unless stub[:zero_long].nil?
         data[:zero_float] = Hearth::NumberHelper.serialize(stub[:zero_float])
         data[:zero_double] = Hearth::NumberHelper.serialize(stub[:zero_double])
+        http_resp.body.write(Hearth::JSON.dump(data))
+      end
+    end
+
+    class OperationWithNestedStructure
+      def self.build(params, context:)
+        Params::OperationWithNestedStructureOutput.build(params, context: context)
+      end
+
+      def self.validate!(output, context:)
+        Validators::OperationWithNestedStructureOutput.validate!(output, context: context)
+      end
+
+      def self.default(visited = [])
+        {
+          dialog: Dialog.default(visited),
+          dialog_list: DialogList.default(visited),
+          dialog_map: DialogMap.default(visited),
+        }
+      end
+
+      def self.stub(http_resp, stub:)
+        data = {}
+        http_resp.status = 200
+        http_resp.headers['Content-Type'] = 'application/json'
+        data[:dialog] = Stubs::Dialog.stub(stub[:dialog]) unless stub[:dialog].nil?
+        data[:dialog_list] = Stubs::DialogList.stub(stub[:dialog_list]) unless stub[:dialog_list].nil?
+        data[:dialog_map] = Stubs::DialogMap.stub(stub[:dialog_map]) unless stub[:dialog_map].nil?
         http_resp.body.write(Hearth::JSON.dump(data))
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -380,6 +380,33 @@ module RailsJson
 
     # @!method initialize(params = {})
     #   @param [Hash] params
+    #   @option params [String] :language
+    #   @option params [String] :greeting
+    #   @option params [Farewell] :farewell
+    # @!attribute language
+    #   @return [String]
+    # @!attribute greeting
+    #   @return [String]
+    # @!attribute farewell
+    #   @return [Farewell]
+    Dialog = ::Struct.new(
+      :language,
+      :greeting,
+      :farewell,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          greeting: "hi"
+        }
+      end
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
     #   @option params [Hash<String, Hash, Array, String, Boolean, Numeric>] :doc_valued_map
     # @!attribute doc_valued_map
     #   @return [Hash<String, Hash, Array, String, Boolean, Numeric>]
@@ -513,6 +540,25 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [String] :phrase
+    # @!attribute phrase
+    #   @return [String]
+    Farewell = ::Struct.new(
+      :phrase,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          phrase: "bye"
+        }
+      end
     end
 
     # Enum constants for FooEnum
@@ -2160,6 +2206,46 @@ module RailsJson
 
     # @!method initialize(params = {})
     #   @param [Hash] params
+    #   @option params [TopLevel] :top_level
+    # @!attribute top_level
+    #   @return [TopLevel]
+    OperationWithNestedStructureInput = ::Struct.new(
+      :top_level,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [Dialog] :dialog
+    #   @option params [Array<Dialog>] :dialog_list
+    #   @option params [Hash<String, Dialog>] :dialog_map
+    # @!attribute dialog
+    #   @return [Dialog]
+    # @!attribute dialog_list
+    #   @return [Array<Dialog>]
+    # @!attribute dialog_map
+    #   @return [Hash<String, Dialog>]
+    OperationWithNestedStructureOutput = ::Struct.new(
+      :dialog,
+      :dialog_list,
+      :dialog_map,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          dialog_list: [],
+          dialog_map: {}
+        }
+      end
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
     #   @option params [Integer] :data
     # @!attribute data
     #   @return [Integer]
@@ -2927,6 +3013,34 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [Dialog] :dialog
+    #   @option params [Array<Dialog>] :dialog_list
+    #   @option params [Hash<String, Dialog>] :dialog_map
+    # @!attribute dialog
+    #   @return [Dialog]
+    # @!attribute dialog_list
+    #   @return [Array<Dialog>]
+    # @!attribute dialog_map
+    #   @return [Hash<String, Dialog>]
+    TopLevel = ::Struct.new(
+      :dialog,
+      :dialog_list,
+      :dialog_map,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          dialog_list: [],
+          dialog_map: {}
+        }
+      end
     end
 
     class UnionPayload < Hearth::Union

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -112,6 +112,18 @@ module RailsJson
       include Hearth::Structure
     end
 
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [Integer] :member
+    # @!attribute member
+    #   @return [Integer]
+    ClientOptionalDefaults = ::Struct.new(
+      :member,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
     # This error is thrown when a request is invalid.
     # @!method initialize(params = {})
     #   @param [Hash] params
@@ -210,6 +222,160 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [String] :default_string
+    #   @option params [Boolean] :default_boolean
+    #   @option params [Array<String>] :default_list
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_map
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_string
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_boolean
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_list
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_null_document
+    #   @option params [Time] :default_timestamp
+    #   @option params [String] :default_blob
+    #   @option params [Integer] :default_byte
+    #   @option params [Integer] :default_short
+    #   @option params [Integer] :default_integer
+    #   @option params [Integer] :default_long
+    #   @option params [Float] :default_float
+    #   @option params [Float] :default_double
+    #   @option params [Hash<String, String>] :default_map
+    #   @option params [String] :default_enum
+    #   @option params [Integer] :default_int_enum
+    #   @option params [String] :empty_string
+    #   @option params [Boolean] :false_boolean (false)
+    #   @option params [String] :empty_blob
+    #   @option params [Integer] :zero_byte (0)
+    #   @option params [Integer] :zero_short (0)
+    #   @option params [Integer] :zero_integer (0)
+    #   @option params [Integer] :zero_long (0)
+    #   @option params [Float] :zero_float (0)
+    #   @option params [Float] :zero_double (0)
+    # @!attribute default_string
+    #   @return [String]
+    # @!attribute default_boolean
+    #   @return [Boolean]
+    # @!attribute default_list
+    #   @return [Array<String>]
+    # @!attribute default_document_map
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_document_string
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_document_boolean
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_document_list
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_null_document
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_timestamp
+    #   @return [Time]
+    # @!attribute default_blob
+    #   @return [String]
+    # @!attribute default_byte
+    #   @return [Integer]
+    # @!attribute default_short
+    #   @return [Integer]
+    # @!attribute default_integer
+    #   @return [Integer]
+    # @!attribute default_long
+    #   @return [Integer]
+    # @!attribute default_float
+    #   @return [Float]
+    # @!attribute default_double
+    #   @return [Float]
+    # @!attribute default_map
+    #   @return [Hash<String, String>]
+    # @!attribute default_enum
+    #   Enum, one of: ["FOO", "BAR", "BAZ"]
+    #   @return [String]
+    # @!attribute default_int_enum
+    #   @return [Integer]
+    # @!attribute empty_string
+    #   @return [String]
+    # @!attribute false_boolean
+    #   @return [Boolean]
+    # @!attribute empty_blob
+    #   @return [String]
+    # @!attribute zero_byte
+    #   @return [Integer]
+    # @!attribute zero_short
+    #   @return [Integer]
+    # @!attribute zero_integer
+    #   @return [Integer]
+    # @!attribute zero_long
+    #   @return [Integer]
+    # @!attribute zero_float
+    #   @return [Float]
+    # @!attribute zero_double
+    #   @return [Float]
+    Defaults = ::Struct.new(
+      :default_string,
+      :default_boolean,
+      :default_list,
+      :default_document_map,
+      :default_document_string,
+      :default_document_boolean,
+      :default_document_list,
+      :default_null_document,
+      :default_timestamp,
+      :default_blob,
+      :default_byte,
+      :default_short,
+      :default_integer,
+      :default_long,
+      :default_float,
+      :default_double,
+      :default_map,
+      :default_enum,
+      :default_int_enum,
+      :empty_string,
+      :false_boolean,
+      :empty_blob,
+      :zero_byte,
+      :zero_short,
+      :zero_integer,
+      :zero_long,
+      :zero_float,
+      :zero_double,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          default_string: "hi",
+          default_boolean: true,
+          default_list: [],
+          default_document_map: {},
+          default_document_string: "hi",
+          default_document_boolean: true,
+          default_document_list: [],
+          default_timestamp: Time.at(0),
+          default_blob: "abc",
+          default_byte: 1,
+          default_short: 1,
+          default_integer: 10,
+          default_long: 100,
+          default_float: 1.0.to_f,
+          default_double: 1.0.to_f,
+          default_map: {},
+          default_enum: "FOO",
+          default_int_enum: 1,
+          empty_string: "",
+          false_boolean: false,
+          empty_blob: "",
+          zero_byte: 0,
+          zero_short: 0,
+          zero_integer: 0,
+          zero_long: 0,
+          zero_float: 0.0.to_f,
+          zero_double: 0.0.to_f
+        }
+      end
     end
 
     # @!method initialize(params = {})
@@ -1816,6 +1982,184 @@ module RailsJson
 
     # @!method initialize(params = {})
     #   @param [Hash] params
+    #   @option params [Defaults] :defaults
+    #   @option params [ClientOptionalDefaults] :client_optional_defaults
+    #   @option params [String] :top_level_default
+    #   @option params [Integer] :other_top_level_default (0)
+    # @!attribute defaults
+    #   @return [Defaults]
+    # @!attribute client_optional_defaults
+    #   @return [ClientOptionalDefaults]
+    # @!attribute top_level_default
+    #   @return [String]
+    # @!attribute other_top_level_default
+    #   @return [Integer]
+    OperationWithDefaultsInput = ::Struct.new(
+      :defaults,
+      :client_optional_defaults,
+      :top_level_default,
+      :other_top_level_default,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [String] :default_string
+    #   @option params [Boolean] :default_boolean
+    #   @option params [Array<String>] :default_list
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_map
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_string
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_boolean
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_document_list
+    #   @option params [Hash, Array, String, Boolean, Numeric] :default_null_document
+    #   @option params [Time] :default_timestamp
+    #   @option params [String] :default_blob
+    #   @option params [Integer] :default_byte
+    #   @option params [Integer] :default_short
+    #   @option params [Integer] :default_integer
+    #   @option params [Integer] :default_long
+    #   @option params [Float] :default_float
+    #   @option params [Float] :default_double
+    #   @option params [Hash<String, String>] :default_map
+    #   @option params [String] :default_enum
+    #   @option params [Integer] :default_int_enum
+    #   @option params [String] :empty_string
+    #   @option params [Boolean] :false_boolean (false)
+    #   @option params [String] :empty_blob
+    #   @option params [Integer] :zero_byte (0)
+    #   @option params [Integer] :zero_short (0)
+    #   @option params [Integer] :zero_integer (0)
+    #   @option params [Integer] :zero_long (0)
+    #   @option params [Float] :zero_float (0)
+    #   @option params [Float] :zero_double (0)
+    # @!attribute default_string
+    #   @return [String]
+    # @!attribute default_boolean
+    #   @return [Boolean]
+    # @!attribute default_list
+    #   @return [Array<String>]
+    # @!attribute default_document_map
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_document_string
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_document_boolean
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_document_list
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_null_document
+    #   @return [Hash, Array, String, Boolean, Numeric]
+    # @!attribute default_timestamp
+    #   @return [Time]
+    # @!attribute default_blob
+    #   @return [String]
+    # @!attribute default_byte
+    #   @return [Integer]
+    # @!attribute default_short
+    #   @return [Integer]
+    # @!attribute default_integer
+    #   @return [Integer]
+    # @!attribute default_long
+    #   @return [Integer]
+    # @!attribute default_float
+    #   @return [Float]
+    # @!attribute default_double
+    #   @return [Float]
+    # @!attribute default_map
+    #   @return [Hash<String, String>]
+    # @!attribute default_enum
+    #   Enum, one of: ["FOO", "BAR", "BAZ"]
+    #   @return [String]
+    # @!attribute default_int_enum
+    #   @return [Integer]
+    # @!attribute empty_string
+    #   @return [String]
+    # @!attribute false_boolean
+    #   @return [Boolean]
+    # @!attribute empty_blob
+    #   @return [String]
+    # @!attribute zero_byte
+    #   @return [Integer]
+    # @!attribute zero_short
+    #   @return [Integer]
+    # @!attribute zero_integer
+    #   @return [Integer]
+    # @!attribute zero_long
+    #   @return [Integer]
+    # @!attribute zero_float
+    #   @return [Float]
+    # @!attribute zero_double
+    #   @return [Float]
+    OperationWithDefaultsOutput = ::Struct.new(
+      :default_string,
+      :default_boolean,
+      :default_list,
+      :default_document_map,
+      :default_document_string,
+      :default_document_boolean,
+      :default_document_list,
+      :default_null_document,
+      :default_timestamp,
+      :default_blob,
+      :default_byte,
+      :default_short,
+      :default_integer,
+      :default_long,
+      :default_float,
+      :default_double,
+      :default_map,
+      :default_enum,
+      :default_int_enum,
+      :empty_string,
+      :false_boolean,
+      :empty_blob,
+      :zero_byte,
+      :zero_short,
+      :zero_integer,
+      :zero_long,
+      :zero_float,
+      :zero_double,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          default_string: "hi",
+          default_boolean: true,
+          default_list: [],
+          default_document_map: {},
+          default_document_string: "hi",
+          default_document_boolean: true,
+          default_document_list: [],
+          default_timestamp: Time.at(0),
+          default_blob: "abc",
+          default_byte: 1,
+          default_short: 1,
+          default_integer: 10,
+          default_long: 100,
+          default_float: 1.0.to_f,
+          default_double: 1.0.to_f,
+          default_map: {},
+          default_enum: "FOO",
+          default_int_enum: 1,
+          empty_string: "",
+          false_boolean: false,
+          empty_blob: "",
+          zero_byte: 0,
+          zero_short: 0,
+          zero_integer: 0,
+          zero_long: 0,
+          zero_float: 0.0.to_f,
+          zero_double: 0.0.to_f
+        }
+      end
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
     #   @option params [Integer] :data
     # @!attribute data
     #   @return [Integer]
@@ -2271,6 +2615,13 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          blob: ""
+        }
+      end
     end
 
     # @!method initialize(params = {})
@@ -2328,6 +2679,13 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+
+      private
+      def _defaults
+        {
+          blob: ""
+        }
+      end
     end
 
     # Enum constants for StringEnum
@@ -2393,6 +2751,22 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+    end
+
+    # Enum constants for TestEnum
+    module TestEnum
+      FOO = "FOO"
+
+      BAR = "BAR"
+
+      BAZ = "BAZ"
+    end
+
+    # Enum constants for TestIntEnum
+    module TestIntEnum
+      ONE = 1
+
+      TWO = 2
     end
 
     # @!method initialize(params = {})

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -345,6 +345,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           default_string: "hi",
@@ -398,6 +399,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           greeting: "hi"
@@ -554,6 +556,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           phrase: "bye"
@@ -2171,6 +2174,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           default_string: "hi",
@@ -2236,6 +2240,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           dialog_list: [],
@@ -2703,6 +2708,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           blob: ""
@@ -2767,6 +2773,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           blob: ""
@@ -3035,6 +3042,7 @@ module RailsJson
       include Hearth::Structure
 
       private
+
       def _defaults
         {
           dialog_list: [],

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -55,6 +55,13 @@ module RailsJson
       end
     end
 
+    class ClientOptionalDefaults
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::ClientOptionalDefaults, context: context)
+        Hearth::Validator.validate_types!(input[:member], ::Integer, context: "#{context}[:member]")
+      end
+    end
+
     class ComplexError
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, Types::ComplexError, context: context)
@@ -109,6 +116,40 @@ module RailsJson
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, Types::DatetimeOffsetsOutput, context: context)
         Hearth::Validator.validate_types!(input[:datetime], ::Time, context: "#{context}[:datetime]")
+      end
+    end
+
+    class Defaults
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::Defaults, context: context)
+        Hearth::Validator.validate_types!(input[:default_string], ::String, context: "#{context}[:default_string]")
+        Hearth::Validator.validate_types!(input[:default_boolean], ::TrueClass, ::FalseClass, context: "#{context}[:default_boolean]")
+        TestStringList.validate!(input[:default_list], context: "#{context}[:default_list]") unless input[:default_list].nil?
+        Document.validate!(input[:default_document_map], context: "#{context}[:default_document_map]") unless input[:default_document_map].nil?
+        Document.validate!(input[:default_document_string], context: "#{context}[:default_document_string]") unless input[:default_document_string].nil?
+        Document.validate!(input[:default_document_boolean], context: "#{context}[:default_document_boolean]") unless input[:default_document_boolean].nil?
+        Document.validate!(input[:default_document_list], context: "#{context}[:default_document_list]") unless input[:default_document_list].nil?
+        Document.validate!(input[:default_null_document], context: "#{context}[:default_null_document]") unless input[:default_null_document].nil?
+        Hearth::Validator.validate_types!(input[:default_timestamp], ::Time, context: "#{context}[:default_timestamp]")
+        Hearth::Validator.validate_types!(input[:default_blob], ::String, context: "#{context}[:default_blob]")
+        Hearth::Validator.validate_types!(input[:default_byte], ::Integer, context: "#{context}[:default_byte]")
+        Hearth::Validator.validate_types!(input[:default_short], ::Integer, context: "#{context}[:default_short]")
+        Hearth::Validator.validate_types!(input[:default_integer], ::Integer, context: "#{context}[:default_integer]")
+        Hearth::Validator.validate_types!(input[:default_long], ::Integer, context: "#{context}[:default_long]")
+        Hearth::Validator.validate_types!(input[:default_float], ::Float, context: "#{context}[:default_float]")
+        Hearth::Validator.validate_types!(input[:default_double], ::Float, context: "#{context}[:default_double]")
+        TestStringMap.validate!(input[:default_map], context: "#{context}[:default_map]") unless input[:default_map].nil?
+        Hearth::Validator.validate_types!(input[:default_enum], ::String, context: "#{context}[:default_enum]")
+        Hearth::Validator.validate_types!(input[:default_int_enum], ::Integer, context: "#{context}[:default_int_enum]")
+        Hearth::Validator.validate_types!(input[:empty_string], ::String, context: "#{context}[:empty_string]")
+        Hearth::Validator.validate_types!(input[:false_boolean], ::TrueClass, ::FalseClass, context: "#{context}[:false_boolean]")
+        Hearth::Validator.validate_types!(input[:empty_blob], ::String, context: "#{context}[:empty_blob]")
+        Hearth::Validator.validate_types!(input[:zero_byte], ::Integer, context: "#{context}[:zero_byte]")
+        Hearth::Validator.validate_types!(input[:zero_short], ::Integer, context: "#{context}[:zero_short]")
+        Hearth::Validator.validate_types!(input[:zero_integer], ::Integer, context: "#{context}[:zero_integer]")
+        Hearth::Validator.validate_types!(input[:zero_long], ::Integer, context: "#{context}[:zero_long]")
+        Hearth::Validator.validate_types!(input[:zero_float], ::Float, context: "#{context}[:zero_float]")
+        Hearth::Validator.validate_types!(input[:zero_double], ::Float, context: "#{context}[:zero_double]")
       end
     end
 
@@ -1086,6 +1127,50 @@ module RailsJson
       end
     end
 
+    class OperationWithDefaultsInput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::OperationWithDefaultsInput, context: context)
+        Defaults.validate!(input[:defaults], context: "#{context}[:defaults]") unless input[:defaults].nil?
+        ClientOptionalDefaults.validate!(input[:client_optional_defaults], context: "#{context}[:client_optional_defaults]") unless input[:client_optional_defaults].nil?
+        Hearth::Validator.validate_types!(input[:top_level_default], ::String, context: "#{context}[:top_level_default]")
+        Hearth::Validator.validate_types!(input[:other_top_level_default], ::Integer, context: "#{context}[:other_top_level_default]")
+      end
+    end
+
+    class OperationWithDefaultsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::OperationWithDefaultsOutput, context: context)
+        Hearth::Validator.validate_types!(input[:default_string], ::String, context: "#{context}[:default_string]")
+        Hearth::Validator.validate_types!(input[:default_boolean], ::TrueClass, ::FalseClass, context: "#{context}[:default_boolean]")
+        TestStringList.validate!(input[:default_list], context: "#{context}[:default_list]") unless input[:default_list].nil?
+        Document.validate!(input[:default_document_map], context: "#{context}[:default_document_map]") unless input[:default_document_map].nil?
+        Document.validate!(input[:default_document_string], context: "#{context}[:default_document_string]") unless input[:default_document_string].nil?
+        Document.validate!(input[:default_document_boolean], context: "#{context}[:default_document_boolean]") unless input[:default_document_boolean].nil?
+        Document.validate!(input[:default_document_list], context: "#{context}[:default_document_list]") unless input[:default_document_list].nil?
+        Document.validate!(input[:default_null_document], context: "#{context}[:default_null_document]") unless input[:default_null_document].nil?
+        Hearth::Validator.validate_types!(input[:default_timestamp], ::Time, context: "#{context}[:default_timestamp]")
+        Hearth::Validator.validate_types!(input[:default_blob], ::String, context: "#{context}[:default_blob]")
+        Hearth::Validator.validate_types!(input[:default_byte], ::Integer, context: "#{context}[:default_byte]")
+        Hearth::Validator.validate_types!(input[:default_short], ::Integer, context: "#{context}[:default_short]")
+        Hearth::Validator.validate_types!(input[:default_integer], ::Integer, context: "#{context}[:default_integer]")
+        Hearth::Validator.validate_types!(input[:default_long], ::Integer, context: "#{context}[:default_long]")
+        Hearth::Validator.validate_types!(input[:default_float], ::Float, context: "#{context}[:default_float]")
+        Hearth::Validator.validate_types!(input[:default_double], ::Float, context: "#{context}[:default_double]")
+        TestStringMap.validate!(input[:default_map], context: "#{context}[:default_map]") unless input[:default_map].nil?
+        Hearth::Validator.validate_types!(input[:default_enum], ::String, context: "#{context}[:default_enum]")
+        Hearth::Validator.validate_types!(input[:default_int_enum], ::Integer, context: "#{context}[:default_int_enum]")
+        Hearth::Validator.validate_types!(input[:empty_string], ::String, context: "#{context}[:empty_string]")
+        Hearth::Validator.validate_types!(input[:false_boolean], ::TrueClass, ::FalseClass, context: "#{context}[:false_boolean]")
+        Hearth::Validator.validate_types!(input[:empty_blob], ::String, context: "#{context}[:empty_blob]")
+        Hearth::Validator.validate_types!(input[:zero_byte], ::Integer, context: "#{context}[:zero_byte]")
+        Hearth::Validator.validate_types!(input[:zero_short], ::Integer, context: "#{context}[:zero_short]")
+        Hearth::Validator.validate_types!(input[:zero_integer], ::Integer, context: "#{context}[:zero_integer]")
+        Hearth::Validator.validate_types!(input[:zero_long], ::Integer, context: "#{context}[:zero_long]")
+        Hearth::Validator.validate_types!(input[:zero_float], ::Float, context: "#{context}[:zero_float]")
+        Hearth::Validator.validate_types!(input[:zero_double], ::Float, context: "#{context}[:zero_double]")
+      end
+    end
+
     class PayloadConfig
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, Types::PayloadConfig, context: context)
@@ -1535,6 +1620,25 @@ module RailsJson
         Hearth::Validator.validate_types!(input, Types::TestPayloadStructureOutput, context: context)
         Hearth::Validator.validate_types!(input[:test_id], ::String, context: "#{context}[:test_id]")
         PayloadConfig.validate!(input[:payload_config], context: "#{context}[:payload_config]") unless input[:payload_config].nil?
+      end
+    end
+
+    class TestStringList
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Hearth::Validator.validate_types!(element, ::String, context: "#{context}[#{index}]")
+        end
+      end
+    end
+
+    class TestStringMap
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, ::Hash, context: context)
+        input.each do |key, value|
+          Hearth::Validator.validate_types!(key, ::String, ::Symbol, context: "#{context}.keys")
+          Hearth::Validator.validate_types!(value, ::String, context: "#{context}[:#{key}]")
+        end
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -203,6 +203,34 @@ module RailsJson
       end
     end
 
+    class Dialog
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::Dialog, context: context)
+        Hearth::Validator.validate_types!(input[:language], ::String, context: "#{context}[:language]")
+        Hearth::Validator.validate_types!(input[:greeting], ::String, context: "#{context}[:greeting]")
+        Farewell.validate!(input[:farewell], context: "#{context}[:farewell]") unless input[:farewell].nil?
+      end
+    end
+
+    class DialogList
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Dialog.validate!(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+      end
+    end
+
+    class DialogMap
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, ::Hash, context: context)
+        input.each do |key, value|
+          Hearth::Validator.validate_types!(key, ::String, ::Symbol, context: "#{context}.keys")
+          Dialog.validate!(value, context: "#{context}[:#{key}]") unless value.nil?
+        end
+      end
+    end
+
     class Document
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, ::Hash, ::String, ::Array, ::TrueClass, ::FalseClass, ::Numeric, context: context)
@@ -317,6 +345,13 @@ module RailsJson
     class EndpointWithHostLabelOperationOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, Types::EndpointWithHostLabelOperationOutput, context: context)
+      end
+    end
+
+    class Farewell
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::Farewell, context: context)
+        Hearth::Validator.validate_types!(input[:phrase], ::String, context: "#{context}[:phrase]")
       end
     end
 
@@ -1171,6 +1206,24 @@ module RailsJson
       end
     end
 
+    class OperationWithNestedStructureInput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::OperationWithNestedStructureInput, context: context)
+        Hearth::Validator.validate_required!(input[:top_level], context: "#{context}[:top_level]")
+        TopLevel.validate!(input[:top_level], context: "#{context}[:top_level]") unless input[:top_level].nil?
+      end
+    end
+
+    class OperationWithNestedStructureOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::OperationWithNestedStructureOutput, context: context)
+        Hearth::Validator.validate_required!(input[:dialog], context: "#{context}[:dialog]")
+        Dialog.validate!(input[:dialog], context: "#{context}[:dialog]") unless input[:dialog].nil?
+        DialogList.validate!(input[:dialog_list], context: "#{context}[:dialog_list]") unless input[:dialog_list].nil?
+        DialogMap.validate!(input[:dialog_map], context: "#{context}[:dialog_map]") unless input[:dialog_map].nil?
+      end
+    end
+
     class PayloadConfig
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, Types::PayloadConfig, context: context)
@@ -1674,6 +1727,16 @@ module RailsJson
         input.each_with_index do |element, index|
           Hearth::Validator.validate_types!(element, ::Time, context: "#{context}[#{index}]")
         end
+      end
+    end
+
+    class TopLevel
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::TopLevel, context: context)
+        Hearth::Validator.validate_required!(input[:dialog], context: "#{context}[:dialog]")
+        Dialog.validate!(input[:dialog], context: "#{context}[:dialog]") unless input[:dialog].nil?
+        DialogList.validate!(input[:dialog_list], context: "#{context}[:dialog_list]") unless input[:dialog_list].nil?
+        DialogMap.validate!(input[:dialog_map], context: "#{context}[:dialog_map]") unless input[:dialog_map].nil?
       end
     end
 

--- a/codegen/projections/rails_json/sig/rails_json/client.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/client.rbs
@@ -374,6 +374,46 @@ module RailsJson
         ?query_integer_enum_list: ::Array[::Integer]
       ) -> Hearth::Output[Types::OmitsSerializingEmptyListsOutput]
 
+    def operation_with_defaults: (?::Hash[::Symbol, untyped] params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::OperationWithDefaultsOutput] |
+      (?Types::OperationWithDefaultsInput params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::OperationWithDefaultsOutput] |
+      (
+        ?defaults: {
+          default_string: ::String,
+          default_boolean: bool,
+          default_list: ::Array[::String],
+          default_document_map: Hearth::document,
+          default_document_string: Hearth::document,
+          default_document_boolean: Hearth::document,
+          default_document_list: Hearth::document,
+          default_null_document: Hearth::document,
+          default_timestamp: ::Time,
+          default_blob: ::String,
+          default_byte: ::Integer,
+          default_short: ::Integer,
+          default_integer: ::Integer,
+          default_long: ::Integer,
+          default_float: ::Float,
+          default_double: ::Float,
+          default_map: ::Hash[::String, ::String],
+          default_enum: ("FOO" | "BAR" | "BAZ"),
+          default_int_enum: ::Integer,
+          empty_string: ::String,
+          false_boolean: bool,
+          empty_blob: ::String,
+          zero_byte: ::Integer,
+          zero_short: ::Integer,
+          zero_integer: ::Integer,
+          zero_long: ::Integer,
+          zero_float: ::Float,
+          zero_double: ::Float
+        },
+        ?client_optional_defaults: {
+          member: ::Integer
+        },
+        ?top_level_default: ::String,
+        ?other_top_level_default: ::Integer
+      ) -> Hearth::Output[Types::OperationWithDefaultsOutput]
+
     def post_player_action: (?::Hash[::Symbol, untyped] params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::PostPlayerActionOutput] |
       (?Types::PostPlayerActionInput params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::PostPlayerActionOutput] |
       (

--- a/codegen/projections/rails_json/sig/rails_json/client.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/client.rbs
@@ -414,6 +414,20 @@ module RailsJson
         ?other_top_level_default: ::Integer
       ) -> Hearth::Output[Types::OperationWithDefaultsOutput]
 
+    def operation_with_nested_structure: (?::Hash[::Symbol, untyped] params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::OperationWithNestedStructureOutput] |
+      (?Types::OperationWithNestedStructureInput params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::OperationWithNestedStructureOutput] |
+      (
+        top_level: {
+          dialog: {
+            language: ::String,
+            greeting: ::String,
+            farewell: Types::Farewell
+          },
+          dialog_list: ::Array[Types::Dialog],
+          dialog_map: ::Hash[::String, Types::Dialog]
+        }
+      ) -> Hearth::Output[Types::OperationWithNestedStructureOutput]
+
     def post_player_action: (?::Hash[::Symbol, untyped] params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::PostPlayerActionOutput] |
       (?Types::PostPlayerActionInput params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::PostPlayerActionOutput] |
       (

--- a/codegen/projections/rails_json/sig/rails_json/types.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/types.rbs
@@ -39,6 +39,11 @@ module RailsJson
       include Hearth::Structure
     end
 
+    class ClientOptionalDefaults < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor member (): ::Integer
+    end
+
     class ComplexError < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor header (): ::String
@@ -77,6 +82,38 @@ module RailsJson
     class DatetimeOffsetsOutput < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor datetime (): ::Time
+    end
+
+    class Defaults < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor default_string (): ::String
+      attr_accessor default_boolean (): bool
+      attr_accessor default_list (): ::Array[::String]
+      attr_accessor default_document_map (): Hearth::document
+      attr_accessor default_document_string (): Hearth::document
+      attr_accessor default_document_boolean (): Hearth::document
+      attr_accessor default_document_list (): Hearth::document
+      attr_accessor default_null_document (): Hearth::document
+      attr_accessor default_timestamp (): ::Time
+      attr_accessor default_blob (): ::String
+      attr_accessor default_byte (): ::Integer
+      attr_accessor default_short (): ::Integer
+      attr_accessor default_integer (): ::Integer
+      attr_accessor default_long (): ::Integer
+      attr_accessor default_float (): ::Float
+      attr_accessor default_double (): ::Float
+      attr_accessor default_map (): ::Hash[::String, ::String]
+      attr_accessor default_enum (): ::String
+      attr_accessor default_int_enum (): ::Integer
+      attr_accessor empty_string (): ::String
+      attr_accessor false_boolean (): bool
+      attr_accessor empty_blob (): ::String
+      attr_accessor zero_byte (): ::Integer
+      attr_accessor zero_short (): ::Integer
+      attr_accessor zero_integer (): ::Integer
+      attr_accessor zero_long (): ::Integer
+      attr_accessor zero_float (): ::Float
+      attr_accessor zero_double (): ::Float
     end
 
     class DocumentTypeAsMapValueInput < ::Struct[untyped]
@@ -677,6 +714,46 @@ module RailsJson
       include Hearth::Structure
     end
 
+    class OperationWithDefaultsInput < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor defaults (): Types::Defaults
+      attr_accessor client_optional_defaults (): Types::ClientOptionalDefaults
+      attr_accessor top_level_default (): ::String
+      attr_accessor other_top_level_default (): ::Integer
+    end
+
+    class OperationWithDefaultsOutput < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor default_string (): ::String
+      attr_accessor default_boolean (): bool
+      attr_accessor default_list (): ::Array[::String]
+      attr_accessor default_document_map (): Hearth::document
+      attr_accessor default_document_string (): Hearth::document
+      attr_accessor default_document_boolean (): Hearth::document
+      attr_accessor default_document_list (): Hearth::document
+      attr_accessor default_null_document (): Hearth::document
+      attr_accessor default_timestamp (): ::Time
+      attr_accessor default_blob (): ::String
+      attr_accessor default_byte (): ::Integer
+      attr_accessor default_short (): ::Integer
+      attr_accessor default_integer (): ::Integer
+      attr_accessor default_long (): ::Integer
+      attr_accessor default_float (): ::Float
+      attr_accessor default_double (): ::Float
+      attr_accessor default_map (): ::Hash[::String, ::String]
+      attr_accessor default_enum (): ::String
+      attr_accessor default_int_enum (): ::Integer
+      attr_accessor empty_string (): ::String
+      attr_accessor false_boolean (): bool
+      attr_accessor empty_blob (): ::String
+      attr_accessor zero_byte (): ::Integer
+      attr_accessor zero_short (): ::Integer
+      attr_accessor zero_integer (): ::Integer
+      attr_accessor zero_long (): ::Integer
+      attr_accessor zero_float (): ::Float
+      attr_accessor zero_double (): ::Float
+    end
+
     class PayloadConfig < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor data (): ::Integer
@@ -895,6 +972,20 @@ module RailsJson
     class TestConfig < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor timeout (): ::Integer
+    end
+
+    module TestEnum
+      FOO: ::String
+
+      BAR: ::String
+
+      BAZ: ::String
+    end
+
+    module TestIntEnum
+      ONE: ::Numeric
+
+      TWO: ::Numeric
     end
 
     class TestNoPayloadInput < ::Struct[untyped]

--- a/codegen/projections/rails_json/sig/rails_json/types.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/types.rbs
@@ -116,6 +116,13 @@ module RailsJson
       attr_accessor zero_double (): ::Float
     end
 
+    class Dialog < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor language (): ::String
+      attr_accessor greeting (): ::String
+      attr_accessor farewell (): Types::Farewell
+    end
+
     class DocumentTypeAsMapValueInput < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor doc_valued_map (): ::Hash[::String, Hearth::document]
@@ -171,6 +178,11 @@ module RailsJson
 
     class EndpointWithHostLabelOperationOutput < ::Struct[untyped]
       include Hearth::Structure
+    end
+
+    class Farewell < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor phrase (): ::String
     end
 
     module FooEnum
@@ -754,6 +766,18 @@ module RailsJson
       attr_accessor zero_double (): ::Float
     end
 
+    class OperationWithNestedStructureInput < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor top_level (): Types::TopLevel
+    end
+
+    class OperationWithNestedStructureOutput < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor dialog (): Types::Dialog
+      attr_accessor dialog_list (): ::Array[Types::Dialog]
+      attr_accessor dialog_map (): ::Hash[::String, Types::Dialog]
+    end
+
     class PayloadConfig < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor data (): ::Integer
@@ -1042,6 +1066,13 @@ module RailsJson
       attr_accessor target_epoch_seconds (): ::Time
       attr_accessor target_http_date (): ::Time
       attr_accessor target_date_time (): ::Time
+    end
+
+    class TopLevel < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor dialog (): Types::Dialog
+      attr_accessor dialog_list (): ::Array[Types::Dialog]
+      attr_accessor dialog_map (): ::Hash[::String, Types::Dialog]
     end
 
     class UnionPayload < Hearth::Union

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -6161,6 +6161,299 @@ module RailsJson
 
     end
 
+    describe '#operation_with_nested_structure' do
+
+      describe 'requests' do
+
+        # Client populates nested default values when missing.
+        it 'RailsJsonClientPopulatesNestedDefaultValuesWhenMissing' do
+          proc = proc do |context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/OperationWithNestedStructure')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+                "top_level": {
+                    "dialog": {
+                        "language": "en",
+                        "greeting": "hi"
+                    },
+                    "dialog_list": [
+                        {
+                            "greeting": "hi"
+                        },
+                        {
+                            "greeting": "hi",
+                            "farewell": {
+                                "phrase": "bye"
+                            }
+                        },
+                        {
+                            "language": "it",
+                            "greeting": "ciao",
+                            "farewell": {
+                                "phrase": "arrivederci"
+                            }
+                        }
+                    ],
+                    "dialog_map": {
+                        "emptyDialog": {
+                            "greeting": "hi"
+                        },
+                        "partialEmptyDialog": {
+                            "language": "en",
+                            "greeting": "hi",
+                            "farewell": {
+                                "phrase": "bye"
+                            }
+                        },
+                        "nonEmptyDialog": {
+                            "greeting": "konnichiwa",
+                            "farewell": {
+                                "phrase": "sayonara"
+                            }
+                        }
+                    }
+                }
+            }'))
+          end
+          interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
+          opts = {interceptors: [interceptor]}
+          client.operation_with_nested_structure({
+            top_level: {
+              dialog: {
+                language: "en"
+              },
+              dialog_list: [
+                {
+
+                },
+                {
+                  farewell: {
+
+                  }
+                },
+                {
+                  language: "it",
+                  greeting: "ciao",
+                  farewell: {
+                    phrase: "arrivederci"
+                  }
+                }
+              ],
+              dialog_map: {
+                'emptyDialog' => {
+
+                },
+                'partialEmptyDialog' => {
+                  language: "en",
+                  farewell: {
+
+                  }
+                },
+                'nonEmptyDialog' => {
+                  greeting: "konnichiwa",
+                  farewell: {
+                    phrase: "sayonara"
+                  }
+                }
+              }
+            }
+          }, **opts)
+        end
+
+      end
+
+      describe 'responses' do
+
+        # Client populates nested default values when missing in response body.
+        it 'RailsJsonClientPopulatesNestedDefaultsWhenMissingInResponseBody' do
+          response = Hearth::HTTP::Response.new
+          response.status = 200
+          response.headers['Content-Type'] = 'application/json'
+          response.body.write('{
+              "dialog": {
+                  "language": "en"
+              },
+              "dialog_list": [
+                  {
+                  },
+                  {
+                      "farewell": {}
+                  },
+                  {
+                      "language": "it",
+                      "greeting": "ciao",
+                      "farewell": {
+                          "phrase": "arrivederci"
+                      }
+                  }
+              ],
+              "dialog_map": {
+                  "emptyDialog": {
+                  },
+                  "partialEmptyDialog": {
+                      "language": "en",
+                      "farewell": {}
+                  },
+                  "nonEmptyDialog": {
+                      "greeting": "konnichiwa",
+                      "farewell": {
+                          "phrase": "sayonara"
+                      }
+                  }
+              }
+          }')
+          response.body.rewind
+          client.stub_responses(:operation_with_nested_structure, response)
+          allow(Builders::OperationWithNestedStructure).to receive(:build)
+          output = client.operation_with_nested_structure({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
+          expect(output.data.to_h).to eq({
+            dialog: {
+              language: "en",
+              greeting: "hi"
+            },
+            dialog_list: [
+              {
+                greeting: "hi"
+              },
+              {
+                greeting: "hi",
+                farewell: {
+                  phrase: "bye"
+                }
+              },
+              {
+                language: "it",
+                greeting: "ciao",
+                farewell: {
+                  phrase: "arrivederci"
+                }
+              }
+            ],
+            dialog_map: {
+              'emptyDialog' => {
+                greeting: "hi"
+              },
+              'partialEmptyDialog' => {
+                language: "en",
+                greeting: "hi",
+                farewell: {
+                  phrase: "bye"
+                }
+              },
+              'nonEmptyDialog' => {
+                greeting: "konnichiwa",
+                farewell: {
+                  phrase: "sayonara"
+                }
+              }
+            }
+          })
+        end
+
+      end
+
+      describe 'stubs' do
+
+        # Client populates nested default values when missing in response body.
+        it 'stubs RailsJsonClientPopulatesNestedDefaultsWhenMissingInResponseBody' do
+          proc = proc do |context|
+            expect(context.response.status).to eq(200)
+          end
+          interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
+          allow(Builders::OperationWithNestedStructure).to receive(:build)
+          client.stub_responses(:operation_with_nested_structure, data: {
+            dialog: {
+              language: "en",
+              greeting: "hi"
+            },
+            dialog_list: [
+              {
+                greeting: "hi"
+              },
+              {
+                greeting: "hi",
+                farewell: {
+                  phrase: "bye"
+                }
+              },
+              {
+                language: "it",
+                greeting: "ciao",
+                farewell: {
+                  phrase: "arrivederci"
+                }
+              }
+            ],
+            dialog_map: {
+              'emptyDialog' => {
+                greeting: "hi"
+              },
+              'partialEmptyDialog' => {
+                language: "en",
+                greeting: "hi",
+                farewell: {
+                  phrase: "bye"
+                }
+              },
+              'nonEmptyDialog' => {
+                greeting: "konnichiwa",
+                farewell: {
+                  phrase: "sayonara"
+                }
+              }
+            }
+          })
+          output = client.operation_with_nested_structure({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
+          expect(output.data.to_h).to eq({
+            dialog: {
+              language: "en",
+              greeting: "hi"
+            },
+            dialog_list: [
+              {
+                greeting: "hi"
+              },
+              {
+                greeting: "hi",
+                farewell: {
+                  phrase: "bye"
+                }
+              },
+              {
+                language: "it",
+                greeting: "ciao",
+                farewell: {
+                  phrase: "arrivederci"
+                }
+              }
+            ],
+            dialog_map: {
+              'emptyDialog' => {
+                greeting: "hi"
+              },
+              'partialEmptyDialog' => {
+                language: "en",
+                greeting: "hi",
+                farewell: {
+                  phrase: "bye"
+                }
+              },
+              'nonEmptyDialog' => {
+                greeting: "konnichiwa",
+                farewell: {
+                  phrase: "sayonara"
+                }
+              }
+            }
+          })
+        end
+
+      end
+
+    end
+
     describe '#post_player_action' do
 
       describe 'requests' do

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -5686,6 +5686,481 @@ module RailsJson
 
     end
 
+    describe '#operation_with_defaults' do
+
+      describe 'requests' do
+
+        # Client populates default values in input.
+        it 'RailsJsonClientPopulatesDefaultValuesInInput' do
+          proc = proc do |context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/OperationWithDefaults')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+                "defaults": {
+                    "default_string": "hi",
+                    "default_boolean": true,
+                    "default_list": [],
+                    "default_document_map": {},
+                    "default_document_string": "hi",
+                    "default_document_boolean": true,
+                    "default_document_list": [],
+                    "default_timestamp": "1970-01-01T00:00:00Z",
+                    "default_blob": "YWJj",
+                    "default_byte": 1,
+                    "default_short": 1,
+                    "default_integer": 10,
+                    "default_long": 100,
+                    "default_float": 1.0,
+                    "default_double": 1.0,
+                    "default_map": {},
+                    "default_enum": "FOO",
+                    "default_int_enum": 1,
+                    "empty_string": "",
+                    "false_boolean": false,
+                    "empty_blob": "",
+                    "zero_byte": 0,
+                    "zero_short": 0,
+                    "zero_integer": 0,
+                    "zero_long": 0,
+                    "zero_float": 0.0,
+                    "zero_double": 0.0
+                }
+            }'))
+          end
+          interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
+          opts = {interceptors: [interceptor]}
+          client.operation_with_defaults({
+            defaults: {
+
+            }
+          }, **opts)
+        end
+
+        # Client skips top level default values in input.
+        it 'RailsJsonClientSkipsTopLevelDefaultValuesInInput' do
+          proc = proc do |context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/OperationWithDefaults')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+            }'))
+          end
+          interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
+          opts = {interceptors: [interceptor]}
+          client.operation_with_defaults({
+
+          }, **opts)
+        end
+
+        # Client uses explicitly provided member values over defaults
+        it 'RailsJsonClientUsesExplicitlyProvidedMemberValuesOverDefaults' do
+          proc = proc do |context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/OperationWithDefaults')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+                "defaults": {
+                    "default_string": "bye",
+                    "default_boolean": true,
+                    "default_list": ["a"],
+                    "default_document_map": {"name": "Jack"},
+                    "default_document_string": "bye",
+                    "default_document_boolean": true,
+                    "default_document_list": ["b"],
+                    "default_null_document": "notNull",
+                    "default_timestamp": "1970-01-01T00:00:01Z",
+                    "default_blob": "aGk=",
+                    "default_byte": 2,
+                    "default_short": 2,
+                    "default_integer": 20,
+                    "default_long": 200,
+                    "default_float": 2.0,
+                    "default_double": 2.0,
+                    "default_map": {"name": "Jack"},
+                    "default_enum": "BAR",
+                    "default_int_enum": 2,
+                    "empty_string": "foo",
+                    "false_boolean": true,
+                    "empty_blob": "aGk=",
+                    "zero_byte": 1,
+                    "zero_short": 1,
+                    "zero_integer": 1,
+                    "zero_long": 1,
+                    "zero_float": 1.0,
+                    "zero_double": 1.0
+                }
+            }'))
+          end
+          interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
+          opts = {interceptors: [interceptor]}
+          client.operation_with_defaults({
+            defaults: {
+              default_string: "bye",
+              default_boolean: true,
+              default_list: [
+                "a"
+              ],
+              default_document_map: {'name' => 'Jack'},
+              default_document_string: 'bye',
+              default_document_boolean: true,
+              default_document_list: ['b'],
+              default_null_document: 'notNull',
+              default_timestamp: Time.at(1),
+              default_blob: 'hi',
+              default_byte: 2,
+              default_short: 2,
+              default_integer: 20,
+              default_long: 200,
+              default_float: 2.0,
+              default_double: 2.0,
+              default_map: {
+                'name' => "Jack"
+              },
+              default_enum: "BAR",
+              default_int_enum: 2,
+              empty_string: "foo",
+              false_boolean: true,
+              empty_blob: 'hi',
+              zero_byte: 1,
+              zero_short: 1,
+              zero_integer: 1,
+              zero_long: 1,
+              zero_float: 1.0,
+              zero_double: 1.0
+            }
+          }, **opts)
+        end
+
+        # Any time a value is provided for a member in the top level of input, it is used, regardless of if its the default.
+        it 'RailsJsonClientUsesExplicitlyProvidedValuesInTopLevel' do
+          proc = proc do |context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/OperationWithDefaults')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+                "top_level_default": "hi",
+                "other_top_level_default": 0
+            }'))
+          end
+          interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
+          opts = {interceptors: [interceptor]}
+          client.operation_with_defaults({
+            top_level_default: "hi",
+            other_top_level_default: 0
+          }, **opts)
+        end
+
+        # Typically, non top-level members would have defaults filled in, but if they have the clientOptional trait, the defaults should be ignored.
+        it 'RailsJsonClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional' do
+          proc = proc do |context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/OperationWithDefaults')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+                "client_optional_defaults": {}
+            }'))
+          end
+          interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
+          opts = {interceptors: [interceptor]}
+          client.operation_with_defaults({
+            client_optional_defaults: {
+
+            }
+          }, **opts)
+        end
+
+      end
+
+      describe 'responses' do
+
+        # Client populates default values when missing in response.
+        it 'RailsJsonClientPopulatesDefaultsValuesWhenMissingInResponse' do
+          response = Hearth::HTTP::Response.new
+          response.status = 200
+          response.headers['Content-Type'] = 'application/json'
+          response.body.write('{}')
+          response.body.rewind
+          client.stub_responses(:operation_with_defaults, response)
+          allow(Builders::OperationWithDefaults).to receive(:build)
+          output = client.operation_with_defaults({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
+          expect(output.data.to_h).to eq({
+            default_string: "hi",
+            default_boolean: true,
+            default_list: [
+
+            ],
+            default_document_map: {},
+            default_document_string: 'hi',
+            default_document_boolean: true,
+            default_document_list: [],
+            default_timestamp: Time.at(0),
+            default_blob: 'abc',
+            default_byte: 1,
+            default_short: 1,
+            default_integer: 10,
+            default_long: 100,
+            default_float: 1.0,
+            default_double: 1.0,
+            default_map: {
+
+            },
+            default_enum: "FOO",
+            default_int_enum: 1,
+            empty_string: "",
+            false_boolean: false,
+            empty_blob: '',
+            zero_byte: 0,
+            zero_short: 0,
+            zero_integer: 0,
+            zero_long: 0,
+            zero_float: 0.0,
+            zero_double: 0.0
+          })
+        end
+
+        # Client ignores default values if member values are present in the response.
+        it 'RailsJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse' do
+          response = Hearth::HTTP::Response.new
+          response.status = 200
+          response.headers['Content-Type'] = 'application/json'
+          response.body.write('{
+              "default_string": "bye",
+              "default_boolean": false,
+              "default_list": ["a"],
+              "default_document_map": {"name": "Jack"},
+              "default_document_string": "bye",
+              "default_document_boolean": false,
+              "default_document_list": ["b"],
+              "default_null_document": "notNull",
+              "default_timestamp": "1970-01-01T00:00:01Z",
+              "default_blob": "aGk=",
+              "default_byte": 2,
+              "default_short": 2,
+              "default_integer": 20,
+              "default_long": 200,
+              "default_float": 2.0,
+              "default_double": 2.0,
+              "default_map": {"name": "Jack"},
+              "default_enum": "BAR",
+              "default_int_enum": 2,
+              "empty_string": "foo",
+              "false_boolean": true,
+              "empty_blob": "aGk=",
+              "zero_byte": 1,
+              "zero_short": 1,
+              "zero_integer": 1,
+              "zero_long": 1,
+              "zero_float": 1.0,
+              "zero_double": 1.0
+          }')
+          response.body.rewind
+          client.stub_responses(:operation_with_defaults, response)
+          allow(Builders::OperationWithDefaults).to receive(:build)
+          output = client.operation_with_defaults({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
+          expect(output.data.to_h).to eq({
+            default_string: "bye",
+            default_boolean: false,
+            default_list: [
+              "a"
+            ],
+            default_document_map: {'name' => 'Jack'},
+            default_document_string: 'bye',
+            default_document_boolean: false,
+            default_document_list: ['b'],
+            default_null_document: 'notNull',
+            default_timestamp: Time.at(1),
+            default_blob: 'hi',
+            default_byte: 2,
+            default_short: 2,
+            default_integer: 20,
+            default_long: 200,
+            default_float: 2.0,
+            default_double: 2.0,
+            default_map: {
+              'name' => "Jack"
+            },
+            default_enum: "BAR",
+            default_int_enum: 2,
+            empty_string: "foo",
+            false_boolean: true,
+            empty_blob: 'hi',
+            zero_byte: 1,
+            zero_short: 1,
+            zero_integer: 1,
+            zero_long: 1,
+            zero_float: 1.0,
+            zero_double: 1.0
+          })
+        end
+
+      end
+
+      describe 'stubs' do
+
+        # Client populates default values when missing in response.
+        it 'stubs RailsJsonClientPopulatesDefaultsValuesWhenMissingInResponse' do
+          proc = proc do |context|
+            expect(context.response.status).to eq(200)
+          end
+          interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
+          allow(Builders::OperationWithDefaults).to receive(:build)
+          client.stub_responses(:operation_with_defaults, data: {
+            default_string: "hi",
+            default_boolean: true,
+            default_list: [
+
+            ],
+            default_document_map: {},
+            default_document_string: 'hi',
+            default_document_boolean: true,
+            default_document_list: [],
+            default_timestamp: Time.at(0),
+            default_blob: 'abc',
+            default_byte: 1,
+            default_short: 1,
+            default_integer: 10,
+            default_long: 100,
+            default_float: 1.0,
+            default_double: 1.0,
+            default_map: {
+
+            },
+            default_enum: "FOO",
+            default_int_enum: 1,
+            empty_string: "",
+            false_boolean: false,
+            empty_blob: '',
+            zero_byte: 0,
+            zero_short: 0,
+            zero_integer: 0,
+            zero_long: 0,
+            zero_float: 0.0,
+            zero_double: 0.0
+          })
+          output = client.operation_with_defaults({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
+          expect(output.data.to_h).to eq({
+            default_string: "hi",
+            default_boolean: true,
+            default_list: [
+
+            ],
+            default_document_map: {},
+            default_document_string: 'hi',
+            default_document_boolean: true,
+            default_document_list: [],
+            default_timestamp: Time.at(0),
+            default_blob: 'abc',
+            default_byte: 1,
+            default_short: 1,
+            default_integer: 10,
+            default_long: 100,
+            default_float: 1.0,
+            default_double: 1.0,
+            default_map: {
+
+            },
+            default_enum: "FOO",
+            default_int_enum: 1,
+            empty_string: "",
+            false_boolean: false,
+            empty_blob: '',
+            zero_byte: 0,
+            zero_short: 0,
+            zero_integer: 0,
+            zero_long: 0,
+            zero_float: 0.0,
+            zero_double: 0.0
+          })
+        end
+
+        # Client ignores default values if member values are present in the response.
+        it 'stubs RailsJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse' do
+          proc = proc do |context|
+            expect(context.response.status).to eq(200)
+          end
+          interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
+          allow(Builders::OperationWithDefaults).to receive(:build)
+          client.stub_responses(:operation_with_defaults, data: {
+            default_string: "bye",
+            default_boolean: false,
+            default_list: [
+              "a"
+            ],
+            default_document_map: {'name' => 'Jack'},
+            default_document_string: 'bye',
+            default_document_boolean: false,
+            default_document_list: ['b'],
+            default_null_document: 'notNull',
+            default_timestamp: Time.at(1),
+            default_blob: 'hi',
+            default_byte: 2,
+            default_short: 2,
+            default_integer: 20,
+            default_long: 200,
+            default_float: 2.0,
+            default_double: 2.0,
+            default_map: {
+              'name' => "Jack"
+            },
+            default_enum: "BAR",
+            default_int_enum: 2,
+            empty_string: "foo",
+            false_boolean: true,
+            empty_blob: 'hi',
+            zero_byte: 1,
+            zero_short: 1,
+            zero_integer: 1,
+            zero_long: 1,
+            zero_float: 1.0,
+            zero_double: 1.0
+          })
+          output = client.operation_with_defaults({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
+          expect(output.data.to_h).to eq({
+            default_string: "bye",
+            default_boolean: false,
+            default_list: [
+              "a"
+            ],
+            default_document_map: {'name' => 'Jack'},
+            default_document_string: 'bye',
+            default_document_boolean: false,
+            default_document_list: ['b'],
+            default_null_document: 'notNull',
+            default_timestamp: Time.at(1),
+            default_blob: 'hi',
+            default_byte: 2,
+            default_short: 2,
+            default_integer: 20,
+            default_long: 200,
+            default_float: 2.0,
+            default_double: 2.0,
+            default_map: {
+              'name' => "Jack"
+            },
+            default_enum: "BAR",
+            default_int_enum: 2,
+            empty_string: "foo",
+            false_boolean: true,
+            empty_blob: 'hi',
+            zero_byte: 1,
+            zero_short: 1,
+            zero_integer: 1,
+            zero_long: 1,
+            zero_float: 1.0,
+            zero_double: 1.0
+          })
+        end
+
+      end
+
+    end
+
     describe '#post_player_action' do
 
       describe 'requests' do

--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -21,6 +21,9 @@ module WhiteLabel
       end
     end
 
+    class Defaults
+    end
+
     class DefaultsTest
       def self.build(http_req, input:)
       end

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -116,34 +116,36 @@ module WhiteLabel
     # @return [Hearth::Output]
     # @example Request syntax with placeholder values
     #   resp = client.defaults_test(
-    #     string: 'String',
-    #     struct: {
-    #       value: 'value'
-    #     },
-    #     un_required_number: 1,
-    #     un_required_bool: false,
-    #     number: 1, # required
-    #     bool: false, # required
-    #     hello: 'hello', # required
-    #     simple_enum: 'YES', # required - accepts ["YES", "NO"]
-    #     valued_enum: 'yes', # required - accepts ["yes", "no"]
-    #     int_enum: 1, # required
-    #     null_document: {
-    #       'nil' => nil,
-    #       'number' => 123.0,
-    #       'string' => 'value',
-    #       'boolean' => true,
-    #       'array' => [],
-    #       'map' => {}
-    #     }, # required
-    #     list_of_strings: [
-    #       'member'
-    #     ], # required
-    #     map_of_strings: {
-    #       'key' => 'value'
-    #     }, # required
-    #     iso8601_timestamp: Time.now, # required
-    #     epoch_timestamp: Time.now # required
+    #     defaults: {
+    #       string: 'String',
+    #       struct: {
+    #         value: 'value'
+    #       },
+    #       un_required_number: 1,
+    #       un_required_bool: false,
+    #       number: 1, # required
+    #       bool: false, # required
+    #       hello: 'hello', # required
+    #       simple_enum: 'YES', # required - accepts ["YES", "NO"]
+    #       valued_enum: 'yes', # required - accepts ["yes", "no"]
+    #       int_enum: 1, # required
+    #       null_document: {
+    #         'nil' => nil,
+    #         'number' => 123.0,
+    #         'string' => 'value',
+    #         'boolean' => true,
+    #         'array' => [],
+    #         'map' => {}
+    #       }, # required
+    #       list_of_strings: [
+    #         'member'
+    #       ], # required
+    #       map_of_strings: {
+    #         'key' => 'value'
+    #       }, # required
+    #       iso8601_timestamp: Time.now, # required
+    #       epoch_timestamp: Time.now # required
+    #     }
     #   )
     # @example Response structure
     #   resp.data #=> Types::DefaultsTestOutput

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -16,7 +16,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::ClientError, context: context)
         type = Types::ClientError.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.message = params[:message]
+        type.message = params[:message] unless params[:message].nil?
         type
       end
     end
@@ -57,31 +57,41 @@ module WhiteLabel
       end
     end
 
+    class Defaults
+      def self.build(params, context:)
+        Hearth::Validator.validate_types!(params, ::Hash, Types::Defaults, context: context)
+        type = Types::Defaults.new
+        Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
+        type.string = params[:string] unless params[:string].nil?
+        type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
+        type.un_required_number = params[:un_required_number] unless params[:un_required_number].nil?
+        type.un_required_bool = params[:un_required_bool] unless params[:un_required_bool].nil?
+        type.number = params[:number] unless params[:number].nil?
+        type.bool = params[:bool] unless params[:bool].nil?
+        type.hello = params[:hello] unless params[:hello].nil?
+        type.simple_enum = params[:simple_enum] unless params[:simple_enum].nil?
+        type.valued_enum = params[:valued_enum] unless params[:valued_enum].nil?
+        type.int_enum = params[:int_enum] unless params[:int_enum].nil?
+        type.null_document = params[:null_document] unless params[:null_document].nil?
+        type.string_document = params[:string_document] unless params[:string_document].nil?
+        type.boolean_document = params[:boolean_document] unless params[:boolean_document].nil?
+        type.numbers_document = params[:numbers_document] unless params[:numbers_document].nil?
+        type.list_document = params[:list_document] unless params[:list_document].nil?
+        type.map_document = params[:map_document] unless params[:map_document].nil?
+        type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
+        type.map_of_strings = MapOfStrings.build(params[:map_of_strings], context: "#{context}[:map_of_strings]") unless params[:map_of_strings].nil?
+        type.iso8601_timestamp = params[:iso8601_timestamp] unless params[:iso8601_timestamp].nil?
+        type.epoch_timestamp = params[:epoch_timestamp] unless params[:epoch_timestamp].nil?
+        type
+      end
+    end
+
     class DefaultsTestInput
       def self.build(params, context:)
         Hearth::Validator.validate_types!(params, ::Hash, Types::DefaultsTestInput, context: context)
         type = Types::DefaultsTestInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string = params[:string]
-        type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
-        type.un_required_number = params[:un_required_number]
-        type.un_required_bool = params[:un_required_bool]
-        type.number = params.fetch(:number, 0)
-        type.bool = params.fetch(:bool, false)
-        type.hello = params.fetch(:hello, "world")
-        type.simple_enum = params.fetch(:simple_enum, "YES")
-        type.valued_enum = params.fetch(:valued_enum, "no")
-        type.int_enum = params.fetch(:int_enum, 1)
-        type.null_document = params[:null_document]
-        type.string_document = params.fetch(:string_document, "some string document")
-        type.boolean_document = params.fetch(:boolean_document, true)
-        type.numbers_document = params.fetch(:numbers_document, 1.23)
-        type.list_document = params.fetch(:list_document, [])
-        type.map_document = params.fetch(:map_document, {})
-        type.list_of_strings = ListOfStrings.build(params.fetch(:list_of_strings, []), context: "#{context}[:list_of_strings]")
-        type.map_of_strings = MapOfStrings.build(params.fetch(:map_of_strings, {}), context: "#{context}[:map_of_strings]")
-        type.iso8601_timestamp = params.fetch(:iso8601_timestamp, "1985-04-12T23:20:50.52Z")
-        type.epoch_timestamp = params.fetch(:epoch_timestamp, 1.5155310811234E9)
+        type.defaults = Defaults.build(params[:defaults], context: "#{context}[:defaults]") unless params[:defaults].nil?
         type
       end
     end
@@ -91,26 +101,26 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::DefaultsTestOutput, context: context)
         type = Types::DefaultsTestOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string = params[:string]
+        type.string = params[:string] unless params[:string].nil?
         type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
-        type.un_required_number = params[:un_required_number]
-        type.un_required_bool = params[:un_required_bool]
-        type.number = params.fetch(:number, 0)
-        type.bool = params.fetch(:bool, false)
-        type.hello = params.fetch(:hello, "world")
-        type.simple_enum = params.fetch(:simple_enum, "YES")
-        type.valued_enum = params.fetch(:valued_enum, "no")
-        type.int_enum = params.fetch(:int_enum, 1)
-        type.null_document = params[:null_document]
-        type.string_document = params.fetch(:string_document, "some string document")
-        type.boolean_document = params.fetch(:boolean_document, true)
-        type.numbers_document = params.fetch(:numbers_document, 1.23)
-        type.list_document = params.fetch(:list_document, [])
-        type.map_document = params.fetch(:map_document, {})
-        type.list_of_strings = ListOfStrings.build(params.fetch(:list_of_strings, []), context: "#{context}[:list_of_strings]")
-        type.map_of_strings = MapOfStrings.build(params.fetch(:map_of_strings, {}), context: "#{context}[:map_of_strings]")
-        type.iso8601_timestamp = params.fetch(:iso8601_timestamp, "1985-04-12T23:20:50.52Z")
-        type.epoch_timestamp = params.fetch(:epoch_timestamp, 1.5155310811234E9)
+        type.un_required_number = params[:un_required_number] unless params[:un_required_number].nil?
+        type.un_required_bool = params[:un_required_bool] unless params[:un_required_bool].nil?
+        type.number = params[:number] unless params[:number].nil?
+        type.bool = params[:bool] unless params[:bool].nil?
+        type.hello = params[:hello] unless params[:hello].nil?
+        type.simple_enum = params[:simple_enum] unless params[:simple_enum].nil?
+        type.valued_enum = params[:valued_enum] unless params[:valued_enum].nil?
+        type.int_enum = params[:int_enum] unless params[:int_enum].nil?
+        type.null_document = params[:null_document] unless params[:null_document].nil?
+        type.string_document = params[:string_document] unless params[:string_document].nil?
+        type.boolean_document = params[:boolean_document] unless params[:boolean_document].nil?
+        type.numbers_document = params[:numbers_document] unless params[:numbers_document].nil?
+        type.list_document = params[:list_document] unless params[:list_document].nil?
+        type.map_document = params[:map_document] unless params[:map_document].nil?
+        type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
+        type.map_of_strings = MapOfStrings.build(params[:map_of_strings], context: "#{context}[:map_of_strings]") unless params[:map_of_strings].nil?
+        type.iso8601_timestamp = params[:iso8601_timestamp] unless params[:iso8601_timestamp].nil?
+        type.epoch_timestamp = params[:epoch_timestamp] unless params[:epoch_timestamp].nil?
         type
       end
     end
@@ -138,7 +148,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::EndpointWithHostLabelOperationInput, context: context)
         type = Types::EndpointWithHostLabelOperationInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.label_member = params[:label_member]
+        type.label_member = params[:label_member] unless params[:label_member].nil?
         type
       end
     end
@@ -229,7 +239,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -240,11 +250,11 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::KitchenSinkInput, context: context)
         type = Types::KitchenSinkInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string = params[:string]
-        type.simple_enum = params[:simple_enum]
-        type.valued_enum = params[:valued_enum]
+        type.string = params[:string] unless params[:string].nil?
+        type.simple_enum = params[:simple_enum] unless params[:simple_enum].nil?
+        type.valued_enum = params[:valued_enum] unless params[:valued_enum].nil?
         type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
-        type.document = params[:document]
+        type.document = params[:document] unless params[:document].nil?
         type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
         type.list_of_structs = ListOfStructs.build(params[:list_of_structs], context: "#{context}[:list_of_structs]") unless params[:list_of_structs].nil?
         type.map_of_strings = MapOfStrings.build(params[:map_of_strings], context: "#{context}[:map_of_strings]") unless params[:map_of_strings].nil?
@@ -259,11 +269,11 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::KitchenSinkOutput, context: context)
         type = Types::KitchenSinkOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.string = params[:string]
-        type.simple_enum = params[:simple_enum]
-        type.valued_enum = params[:valued_enum]
+        type.string = params[:string] unless params[:string].nil?
+        type.simple_enum = params[:simple_enum] unless params[:simple_enum].nil?
+        type.valued_enum = params[:valued_enum] unless params[:valued_enum].nil?
         type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
-        type.document = params[:document]
+        type.document = params[:document] unless params[:document].nil?
         type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
         type.list_of_structs = ListOfStructs.build(params[:list_of_structs], context: "#{context}[:list_of_structs]") unless params[:list_of_structs].nil?
         type.map_of_strings = MapOfStrings.build(params[:map_of_strings], context: "#{context}[:map_of_strings]") unless params[:map_of_strings].nil?
@@ -278,7 +288,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Array, context: context)
         data = []
         params.each do |element|
-          data << element
+          data << element unless element.nil?
         end
         data
       end
@@ -300,7 +310,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, context: context)
         data = {}
         params.each do |key, value|
-          data[key] = value
+          data[key] = value unless value.nil?
         end
         data
       end
@@ -322,7 +332,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::MixinTestInput, context: context)
         type = Types::MixinTestInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.user_id = params[:user_id]
+        type.user_id = params[:user_id] unless params[:user_id].nil?
         type
       end
     end
@@ -332,8 +342,8 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::MixinTestOutput, context: context)
         type = Types::MixinTestOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.username = params[:username]
-        type.user_id = params[:user_id]
+        type.username = params[:username] unless params[:username].nil?
+        type.user_id = params[:user_id] unless params[:user_id].nil?
         type
       end
     end
@@ -397,7 +407,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::PaginatorsTestOperationInput, context: context)
         type = Types::PaginatorsTestOperationInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.next_token = params[:next_token]
+        type.next_token = params[:next_token] unless params[:next_token].nil?
         type
       end
     end
@@ -407,7 +417,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::PaginatorsTestOperationOutput, context: context)
         type = Types::PaginatorsTestOperationOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.next_token = params[:next_token]
+        type.next_token = params[:next_token] unless params[:next_token].nil?
         type.items = Items.build(params[:items], context: "#{context}[:items]") unless params[:items].nil?
         type
       end
@@ -418,7 +428,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::PaginatorsTestWithItemsInput, context: context)
         type = Types::PaginatorsTestWithItemsInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.next_token = params[:next_token]
+        type.next_token = params[:next_token] unless params[:next_token].nil?
         type
       end
     end
@@ -428,7 +438,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::PaginatorsTestWithItemsOutput, context: context)
         type = Types::PaginatorsTestWithItemsOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.next_token = params[:next_token]
+        type.next_token = params[:next_token] unless params[:next_token].nil?
         type.items = Items.build(params[:items], context: "#{context}[:items]") unless params[:items].nil?
         type
       end
@@ -457,7 +467,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::RequestCompressionInput, context: context)
         type = Types::RequestCompressionInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.body = params[:body]
+        type.body = params[:body] unless params[:body].nil?
         type
       end
     end
@@ -499,7 +509,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::ResourceEndpointInput, context: context)
         type = Types::ResourceEndpointInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.resource_url = params[:resource_url]
+        type.resource_url = params[:resource_url] unless params[:resource_url].nil?
         type
       end
     end
@@ -518,7 +528,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::ResultWrapper, context: context)
         type = Types::ResultWrapper.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.member___123next_token = params[:member___123next_token]
+        type.member___123next_token = params[:member___123next_token] unless params[:member___123next_token].nil?
         type
       end
     end
@@ -588,7 +598,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::Struct, context: context)
         type = Types::Struct.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.value = params[:value]
+        type.value = params[:value] unless params[:value].nil?
         type
       end
     end
@@ -623,7 +633,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::WaitersTestInput, context: context)
         type = Types::WaitersTestInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.status = params[:status]
+        type.status = params[:status] unless params[:status].nil?
         type
       end
     end
@@ -633,7 +643,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::WaitersTestOutput, context: context)
         type = Types::WaitersTestOutput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.status = params[:status]
+        type.status = params[:status] unless params[:status].nil?
         type
       end
     end
@@ -643,7 +653,7 @@ module WhiteLabel
         Hearth::Validator.validate_types!(params, ::Hash, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
         type = Types::Struct____PaginatorsTestWithBadNamesInput.new
         Hearth::Validator.validate_unknown!(type, params, context: context) if params.is_a?(Hash)
-        type.member___next_token = params[:member___next_token]
+        type.member___next_token = params[:member___next_token] unless params[:member___next_token].nil?
         type
       end
     end

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -139,7 +139,7 @@ module WhiteLabel
     #   @return [Time]
     # @!attribute epoch_timestamp
     #   @return [Time]
-    DefaultsTestInput = ::Struct.new(
+    Defaults = ::Struct.new(
       :string,
       :struct,
       :un_required_number,
@@ -164,16 +164,8 @@ module WhiteLabel
     ) do
       include Hearth::Structure
 
-      def initialize(*)
-        super
-        self.un_required_number = 0 if self.un_required_number.nil?
-        self.un_required_bool = false if self.un_required_bool.nil?
-        self.number = 0 if self.number.nil?
-        self.bool = false if self.bool.nil?
-      end
-
       def to_s
-        "#<struct WhiteLabel::Types::DefaultsTestInput "\
+        "#<struct WhiteLabel::Types::Defaults "\
           "string=#{string || 'nil'}, "\
           "struct=\"[SENSITIVE]\", "\
           "un_required_number=#{un_required_number || 'nil'}, "\
@@ -195,6 +187,41 @@ module WhiteLabel
           "iso8601_timestamp=#{iso8601_timestamp || 'nil'}, "\
           "epoch_timestamp=#{epoch_timestamp || 'nil'}>"
       end
+
+      private
+      def _defaults
+        {
+          un_required_number: 0,
+          un_required_bool: false,
+          number: 0,
+          bool: false,
+          hello: "world",
+          simple_enum: "YES",
+          valued_enum: "no",
+          int_enum: 1,
+          string_document: "some string document",
+          boolean_document: true,
+          numbers_document: 1.23,
+          list_document: [],
+          map_document: {},
+          list_of_strings: [],
+          map_of_strings: {},
+          iso8601_timestamp: Time.parse("1985-04-12T23:20:50.52Z"),
+          epoch_timestamp: Time.at(1.5155310811234E9)
+        }
+      end
+    end
+
+    # @!method initialize(params = {})
+    #   @param [Hash] params
+    #   @option params [Defaults] :defaults
+    # @!attribute defaults
+    #   @return [Defaults]
+    DefaultsTestInput = ::Struct.new(
+      :defaults,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
     end
 
     # @!method initialize(params = {})
@@ -303,14 +330,6 @@ module WhiteLabel
     ) do
       include Hearth::Structure
 
-      def initialize(*)
-        super
-        self.un_required_number = 0 if self.un_required_number.nil?
-        self.un_required_bool = false if self.un_required_bool.nil?
-        self.number = 0 if self.number.nil?
-        self.bool = false if self.bool.nil?
-      end
-
       def to_s
         "#<struct WhiteLabel::Types::DefaultsTestOutput "\
           "string=#{string || 'nil'}, "\
@@ -333,6 +352,29 @@ module WhiteLabel
           "map_of_strings=#{map_of_strings || 'nil'}, "\
           "iso8601_timestamp=#{iso8601_timestamp || 'nil'}, "\
           "epoch_timestamp=#{epoch_timestamp || 'nil'}>"
+      end
+
+      private
+      def _defaults
+        {
+          un_required_number: 0,
+          un_required_bool: false,
+          number: 0,
+          bool: false,
+          hello: "world",
+          simple_enum: "YES",
+          valued_enum: "no",
+          int_enum: 1,
+          string_document: "some string document",
+          boolean_document: true,
+          numbers_document: 1.23,
+          list_document: [],
+          map_document: {},
+          list_of_strings: [],
+          map_of_strings: {},
+          iso8601_timestamp: Time.parse("1985-04-12T23:20:50.52Z"),
+          epoch_timestamp: Time.at(1.5155310811234E9)
+        }
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -189,6 +189,7 @@ module WhiteLabel
       end
 
       private
+
       def _defaults
         {
           un_required_number: 0,
@@ -355,6 +356,7 @@ module WhiteLabel
       end
 
       private
+
       def _defaults
         {
           un_required_number: 0,

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -44,9 +44,9 @@ module WhiteLabel
       end
     end
 
-    class DefaultsTestInput
+    class Defaults
       def self.validate!(input, context:)
-        Hearth::Validator.validate_types!(input, Types::DefaultsTestInput, context: context)
+        Hearth::Validator.validate_types!(input, Types::Defaults, context: context)
         Hearth::Validator.validate_types!(input[:string], ::String, context: "#{context}[:string]")
         Struct.validate!(input[:struct], context: "#{context}[:struct]") unless input[:struct].nil?
         Hearth::Validator.validate_types!(input[:un_required_number], ::Integer, context: "#{context}[:un_required_number]")
@@ -83,6 +83,13 @@ module WhiteLabel
         Hearth::Validator.validate_types!(input[:iso8601_timestamp], ::Time, context: "#{context}[:iso8601_timestamp]")
         Hearth::Validator.validate_required!(input[:epoch_timestamp], context: "#{context}[:epoch_timestamp]")
         Hearth::Validator.validate_types!(input[:epoch_timestamp], ::Time, context: "#{context}[:epoch_timestamp]")
+      end
+    end
+
+    class DefaultsTestInput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::DefaultsTestInput, context: context)
+        Defaults.validate!(input[:defaults], context: "#{context}[:defaults]") unless input[:defaults].nil?
       end
     end
 

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -46,28 +46,30 @@ module WhiteLabel
     def defaults_test: (?::Hash[::Symbol, untyped] params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::DefaultsTestOutput] |
       (?Types::DefaultsTestInput params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::DefaultsTestOutput] |
       (
-        ?string: ::String,
-        ?struct: {
-          value: ::String
-        },
-        ?un_required_number: ::Integer,
-        ?un_required_bool: bool,
-        number: ::Integer,
-        bool: bool,
-        hello: ::String,
-        simple_enum: ("YES" | "NO"),
-        valued_enum: ("yes" | "no"),
-        int_enum: ::Integer,
-        null_document: Hearth::document,
-        string_document: Hearth::document,
-        boolean_document: Hearth::document,
-        numbers_document: Hearth::document,
-        list_document: Hearth::document,
-        map_document: Hearth::document,
-        list_of_strings: ::Array[::String],
-        map_of_strings: ::Hash[::String, ::String],
-        iso8601_timestamp: ::Time,
-        epoch_timestamp: ::Time
+        ?defaults: {
+          string: ::String,
+          struct: {
+            value: ::String
+          },
+          un_required_number: ::Integer,
+          un_required_bool: bool,
+          number: ::Integer,
+          bool: bool,
+          hello: ::String,
+          simple_enum: ("YES" | "NO"),
+          valued_enum: ("yes" | "no"),
+          int_enum: ::Integer,
+          null_document: Hearth::document,
+          string_document: Hearth::document,
+          boolean_document: Hearth::document,
+          numbers_document: Hearth::document,
+          list_document: Hearth::document,
+          map_document: Hearth::document,
+          list_of_strings: ::Array[::String],
+          map_of_strings: ::Hash[::String, ::String],
+          iso8601_timestamp: ::Time,
+          epoch_timestamp: ::Time
+        }
       ) -> Hearth::Output[Types::DefaultsTestOutput]
 
     def endpoint_operation: (?::Hash[::Symbol, untyped] params, ?::Hash[::Symbol, untyped] options)  -> Hearth::Output[Types::EndpointOperationOutput] |

--- a/codegen/projections/white_label/sig/white_label/types.rbs
+++ b/codegen/projections/white_label/sig/white_label/types.rbs
@@ -31,7 +31,7 @@ module WhiteLabel
       include Hearth::Structure
     end
 
-    class DefaultsTestInput < ::Struct[untyped]
+    class Defaults < ::Struct[untyped]
       include Hearth::Structure
       attr_accessor string (): ::String
       attr_accessor struct (): Types::Struct
@@ -53,6 +53,11 @@ module WhiteLabel
       attr_accessor map_of_strings (): ::Hash[::String, ::String]
       attr_accessor iso8601_timestamp (): ::Time
       attr_accessor epoch_timestamp (): ::Time
+    end
+
+    class DefaultsTestInput < ::Struct[untyped]
+      include Hearth::Structure
+      attr_accessor defaults (): Types::Defaults
     end
 
     class DefaultsTestOutput < ::Struct[untyped]

--- a/codegen/projections/white_label/spec/params_spec.rb
+++ b/codegen/projections/white_label/spec/params_spec.rb
@@ -106,8 +106,11 @@ module WhiteLabel
 
     describe DefaultsTestInput do
       include_examples 'validates params', Hash, Types::DefaultsTestInput
-      it 'builds with empty parmas input' do
-        data = DefaultsTestInput.build({ defaults: {} }, context: 'params')
+
+      let(:params) { { defaults: {} } }
+
+      it 'builds with empty params input' do
+        data = DefaultsTestInput.build(params, context: 'params')
         expect(data).to be_a(Types::DefaultsTestInput)
         expected = {
           number: 0,

--- a/codegen/projections/white_label/spec/params_spec.rb
+++ b/codegen/projections/white_label/spec/params_spec.rb
@@ -107,7 +107,7 @@ module WhiteLabel
     describe DefaultsTestInput do
       include_examples 'validates params', Hash, Types::DefaultsTestInput
       it 'builds with empty parmas input' do
-        data = DefaultsTestInput.build({defaults: {}}, context: 'params')
+        data = DefaultsTestInput.build({ defaults: {} }, context: 'params')
         expect(data).to be_a(Types::DefaultsTestInput)
         expected = {
           number: 0,

--- a/codegen/projections/white_label/spec/params_spec.rb
+++ b/codegen/projections/white_label/spec/params_spec.rb
@@ -107,7 +107,7 @@ module WhiteLabel
     describe DefaultsTestInput do
       include_examples 'validates params', Hash, Types::DefaultsTestInput
       it 'builds with empty parmas input' do
-        data = DefaultsTestInput.build({}, context: 'params')
+        data = DefaultsTestInput.build({defaults: {}}, context: 'params')
         expect(data).to be_a(Types::DefaultsTestInput)
         expected = {
           number: 0,
@@ -117,16 +117,18 @@ module WhiteLabel
           valued_enum: 'no',
           int_enum: 1,
           string_document: 'some string document',
+          un_required_bool: false,
+          un_required_number: 0,
           boolean_document: true,
           numbers_document: 1.23,
           list_document: [],
           map_document: {},
           list_of_strings: [],
           map_of_strings: {},
-          epoch_timestamp: 1_515_531_081.1234,
-          iso8601_timestamp: '1985-04-12T23:20:50.52Z'
+          epoch_timestamp: Time.at(1_515_531_081.1234),
+          iso8601_timestamp: Time.parse('1985-04-12T23:20:50.52Z')
         }
-        expect(data.to_h).to eq(expected)
+        expect(data.defaults.to_h).to eq(expected)
       end
     end
 

--- a/codegen/projections/white_label/spec/types_spec.rb
+++ b/codegen/projections/white_label/spec/types_spec.rb
@@ -59,7 +59,7 @@ module WhiteLabel
       end
     end
 
-    describe DefaultsTestInput do
+    describe Defaults do
       it 'has a default value for default_number' do
         expect(subject.un_required_number).to be 0
       end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
@@ -106,8 +106,11 @@ module WhiteLabel
 
     describe DefaultsTestInput do
       include_examples 'validates params', Hash, Types::DefaultsTestInput
-      it 'builds with empty parmas input' do
-        data = DefaultsTestInput.build({ defaults: {} }, context: 'params')
+
+      let(:params) { { defaults: {} } }
+
+      it 'builds with empty params input' do
+        data = DefaultsTestInput.build(params, context: 'params')
         expect(data).to be_a(Types::DefaultsTestInput)
         expected = {
           number: 0,

--- a/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
@@ -107,7 +107,7 @@ module WhiteLabel
     describe DefaultsTestInput do
       include_examples 'validates params', Hash, Types::DefaultsTestInput
       it 'builds with empty parmas input' do
-        data = DefaultsTestInput.build({defaults: {}}, context: 'params')
+        data = DefaultsTestInput.build({ defaults: {} }, context: 'params')
         expect(data).to be_a(Types::DefaultsTestInput)
         expected = {
           number: 0,

--- a/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
@@ -107,7 +107,7 @@ module WhiteLabel
     describe DefaultsTestInput do
       include_examples 'validates params', Hash, Types::DefaultsTestInput
       it 'builds with empty parmas input' do
-        data = DefaultsTestInput.build({}, context: 'params')
+        data = DefaultsTestInput.build({defaults: {}}, context: 'params')
         expect(data).to be_a(Types::DefaultsTestInput)
         expected = {
           number: 0,
@@ -117,16 +117,18 @@ module WhiteLabel
           valued_enum: 'no',
           int_enum: 1,
           string_document: 'some string document',
+          un_required_bool: false,
+          un_required_number: 0,
           boolean_document: true,
           numbers_document: 1.23,
           list_document: [],
           map_document: {},
           list_of_strings: [],
           map_of_strings: {},
-          epoch_timestamp: 1_515_531_081.1234,
-          iso8601_timestamp: '1985-04-12T23:20:50.52Z'
+          epoch_timestamp: Time.at(1_515_531_081.1234),
+          iso8601_timestamp: Time.parse('1985-04-12T23:20:50.52Z')
         }
-        expect(data.to_h).to eq(expected)
+        expect(data.defaults.to_h).to eq(expected)
       end
     end
 

--- a/codegen/smithy-ruby-codegen-test/integration-specs/types_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/types_spec.rb
@@ -59,7 +59,7 @@ module WhiteLabel
       end
     end
 
-    describe DefaultsTestInput do
+    describe Defaults do
       it 'has a default value for default_number' do
         expect(subject.un_required_number).to be 0
       end

--- a/codegen/smithy-ruby-codegen-test/model/component-test/defaults.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/defaults.smithy
@@ -3,11 +3,15 @@ namespace smithy.ruby.tests
 
 @suppress(["HttpBindingsMissing"])
 operation DefaultsTest {
-    input: DefaultsTestInputOutput,
-    output: DefaultsTestInputOutput,
+    input:= {
+        defaults: Defaults
+    }
+    output:= with [DefaultsMixin] {},
 }
+structure Defaults with [DefaultsMixin] {}
 
-structure DefaultsTestInputOutput {
+@mixin
+structure DefaultsMixin {
     String: String,
 
     @suppress(["DeprecatedShape"])

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/types/StructureGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/types/StructureGenerator.java
@@ -111,7 +111,7 @@ public final class StructureGenerator extends RubyGeneratorBase {
 
         if (!defaultMembers.isEmpty()) {
             writer
-                    .write("\nprivate")
+                    .write("\nprivate\n")
                     .openBlock("def _defaults")
                     .openBlock("{")
                     .call(() -> {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/DefaultValueRetriever.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/DefaultValueRetriever.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen.util;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.traits.DefaultTrait;
+
+/**
+ * Default value constrains:
+ * enum: can be set to any valid string value of the enum.
+ * intEnum: can be set to any valid integer value of the enum.
+ * document: can be set to null, `true, false, string, numbers, an empty list, or an empty map.
+ * list: can only be set to an empty list.
+ * map: can only be set to an empty map.
+ * structure: no default value.
+ * union: no default value.
+ * <p>
+ * See https://awslabs.github.io/smithy/2.0/spec/type-refinement-traits.html?highlight=required#default-value-constraints
+ */
+public final class DefaultValueRetriever extends ShapeVisitor.Default<String> {
+
+    private final Node defaultNode;
+
+    public DefaultValueRetriever(MemberShape memberShape) {
+        this.defaultNode = memberShape.expectTrait(DefaultTrait.class).toNode();
+    }
+
+    @Override
+    protected String getDefault(Shape shape) {
+        return "nil";
+    }
+
+    @Override
+    public String blobShape(BlobShape shape) {
+        return getDefaultString();
+    }
+
+    @Override
+    public String booleanShape(BooleanShape shape) {
+        return getDefaultBoolean();
+    }
+
+    @Override
+    public String stringShape(StringShape shape) {
+        return getDefaultString();
+    }
+
+    @Override
+    public String byteShape(ByteShape shape) {
+        return String.valueOf(getDefaultNumber().byteValue());
+    }
+
+    @Override
+    public String shortShape(ShortShape shape) {
+        return String.valueOf(getDefaultNumber().shortValue());
+    }
+
+    @Override
+    public String integerShape(IntegerShape shape) {
+        return String.valueOf(getDefaultNumber().intValue());
+    }
+
+    @Override
+    public String longShape(LongShape shape) {
+        return String.valueOf(getDefaultNumber().longValue());
+    }
+
+    @Override
+    public String floatShape(FloatShape shape) {
+        return String.valueOf(getDefaultNumber().doubleValue()) + ".to_f";
+    }
+
+    @Override
+    public String doubleShape(DoubleShape shape) {
+        return String.valueOf(getDefaultNumber().doubleValue()) + ".to_f";
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        return String.valueOf(getDefaultNumber().intValue());
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        return String.valueOf(getDefaultNumber().floatValue());
+    }
+
+    @Override
+    public String enumShape(EnumShape shape) {
+        return getDefaultString();
+    }
+
+    @Override
+    public String intEnumShape(IntEnumShape shape) {
+        return String.valueOf(getDefaultNumber().intValue());
+    }
+
+    @Override
+    public String listShape(ListShape shape) {
+        if (defaultNode.asArrayNode().isPresent()) {
+            return "[]";
+        }
+        return "nil";
+    }
+
+    @Override
+    public String mapShape(MapShape shape) {
+        if (defaultNode.asObjectNode().isPresent()) {
+            return "{}";
+        }
+        return "nil";
+    }
+
+    @Override
+    public String documentShape(DocumentShape shape) {
+        if (defaultNode.asNumberNode().isPresent()) {
+            return getDefaultNumber().toString();
+        }
+
+        if (defaultNode.asBooleanNode().isPresent()) {
+            return getDefaultBoolean();
+        }
+
+        if (defaultNode.asStringNode().isPresent()) {
+            return getDefaultString();
+        }
+
+        if (defaultNode.asArrayNode().isPresent()) {
+            return "[]";
+        }
+
+        if (defaultNode.asObjectNode().isPresent()) {
+            return "{}";
+        }
+
+        return "nil";
+    }
+
+    @Override
+    public String timestampShape(TimestampShape shape) {
+        if (defaultNode.isStringNode()) {
+            return "Time.parse(" + getDefaultString() + ")";
+        } else if (defaultNode.isNumberNode()) {
+            return "Time.at(" + String.valueOf(getDefaultNumber()) + ")";
+        } else {
+            return "nil";
+        }
+    }
+
+    private String getDefaultString() {
+        return String.format("\"%s\"", defaultNode.expectStringNode().getValue());
+    }
+
+    private String getDefaultBoolean() {
+        return String.valueOf(defaultNode.expectBooleanNode().getValue());
+    }
+
+    private Number getDefaultNumber() {
+        return defaultNode.expectNumberNode().getValue();
+    }
+}

--- a/codegen/smithy-ruby-rails-codegen-test/model/defaults.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/defaults.smithy
@@ -1,0 +1,421 @@
+// This file defines test cases for default value SERDE
+// These tests are taken from: https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/railsJson/defaults.smithy
+$version: "2.0"
+
+namespace smithy.ruby.protocoltests.railsjson
+
+use smithy.ruby.protocols#railsJson
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply OperationWithDefaults @httpRequestTests([
+    {
+        id: "RailsJsonClientPopulatesDefaultValuesInInput"
+        documentation: "Client populates default values in input."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithDefaults"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+                "defaults": {
+                    "default_string": "hi",
+                    "default_boolean": true,
+                    "default_list": [],
+                    "default_document_map": {},
+                    "default_document_string": "hi",
+                    "default_document_boolean": true,
+                    "default_document_list": [],
+                    "default_timestamp": "1970-01-01T00:00:00Z",
+                    "default_blob": "YWJj",
+                    "default_byte": 1,
+                    "default_short": 1,
+                    "default_integer": 10,
+                    "default_long": 100,
+                    "default_float": 1.0,
+                    "default_double": 1.0,
+                    "default_map": {},
+                    "default_enum": "FOO",
+                    "default_int_enum": 1,
+                    "empty_string": "",
+                    "false_boolean": false,
+                    "empty_blob": "",
+                    "zero_byte": 0,
+                    "zero_short": 0,
+                    "zero_integer": 0,
+                    "zero_long": 0,
+                    "zero_float": 0.0,
+                    "zero_double": 0.0
+                }
+            }"""
+        params: {
+            defaults: {}
+        }
+    }
+    {
+        id: "RailsJsonClientSkipsTopLevelDefaultValuesInInput"
+        documentation: "Client skips top level default values in input."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithDefaults"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+            }"""
+        params: {
+        }
+    }
+    {
+        id: "RailsJsonClientUsesExplicitlyProvidedMemberValuesOverDefaults"
+        documentation: "Client uses explicitly provided member values over defaults"
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithDefaults"
+        headers: {"Content-Type": "application/json"}
+        params: {
+            defaults: {
+                defaultString: "bye"
+                defaultBoolean: true
+                defaultList: ["a"]
+                defaultDocumentMap: {name: "Jack"}
+                defaultDocumentString: "bye"
+                defaultDocumentBoolean: true
+                defaultDocumentList: ["b"]
+                defaultNullDocument: "notNull"
+                defaultTimestamp: 1
+                defaultBlob: "hi"
+                defaultByte: 2
+                defaultShort: 2
+                defaultInteger: 20
+                defaultLong: 200
+                defaultFloat: 2.0
+                defaultDouble: 2.0
+                defaultMap: {name: "Jack"}
+                defaultEnum: "BAR"
+                defaultIntEnum: 2
+                emptyString: "foo"
+                falseBoolean: true
+                emptyBlob: "hi"
+                zeroByte: 1
+                zeroShort: 1
+                zeroInteger: 1
+                zeroLong: 1
+                zeroFloat: 1.0
+                zeroDouble: 1.0
+            }
+        }
+        body: """
+            {
+                "defaults": {
+                    "default_string": "bye",
+                    "default_boolean": true,
+                    "default_list": ["a"],
+                    "default_document_map": {"name": "Jack"},
+                    "default_document_string": "bye",
+                    "default_document_boolean": true,
+                    "default_document_list": ["b"],
+                    "default_null_document": "notNull",
+                    "default_timestamp": "1970-01-01T00:00:01Z",
+                    "default_blob": "aGk=",
+                    "default_byte": 2,
+                    "default_short": 2,
+                    "default_integer": 20,
+                    "default_long": 200,
+                    "default_float": 2.0,
+                    "default_double": 2.0,
+                    "default_map": {"name": "Jack"},
+                    "default_enum": "BAR",
+                    "default_int_enum": 2,
+                    "empty_string": "foo",
+                    "false_boolean": true,
+                    "empty_blob": "aGk=",
+                    "zero_byte": 1,
+                    "zero_short": 1,
+                    "zero_integer": 1,
+                    "zero_long": 1,
+                    "zero_float": 1.0,
+                    "zero_double": 1.0
+                }
+            }"""
+    }
+    {
+        id: "RailsJsonServerPopulatesDefaultsWhenMissingInRequestBody"
+        documentation: "Server populates default values when missing in request body."
+        appliesTo: "server"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithDefaults"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+            "defaults": {}
+            }"""
+        params: {
+            defaults: {
+                defaultString: "hi"
+                defaultBoolean: true
+                defaultList: []
+                defaultDocumentMap: {}
+                defaultDocumentString: "hi"
+                defaultDocumentBoolean: true
+                defaultDocumentList: []
+                defaultTimestamp: 0
+                defaultBlob: "abc"
+                defaultByte: 1
+                defaultShort: 1
+                defaultInteger: 10
+                defaultLong: 100
+                defaultFloat: 1.0
+                defaultDouble: 1.0
+                defaultMap: {}
+                defaultEnum: "FOO"
+                defaultIntEnum: 1
+                emptyString: ""
+                falseBoolean: false
+                emptyBlob: ""
+                zeroByte: 0
+                zeroShort: 0
+                zeroInteger: 0
+                zeroLong: 0
+                zeroFloat: 0.0
+                zeroDouble: 0.0
+            },
+            topLevelDefault: "hi"
+            otherTopLevelDefault: 0
+        }
+    }
+    {
+        id: "RailsJsonClientUsesExplicitlyProvidedValuesInTopLevel"
+        documentation: "Any time a value is provided for a member in the top level of input, it is used, regardless of if its the default."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithDefaults"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+                "top_level_default": "hi",
+                "other_top_level_default": 0
+            }"""
+        params: {
+            topLevelDefault: "hi"
+            otherTopLevelDefault: 0
+        }
+    }
+    {
+        id: "RailsJsonClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional"
+        documentation: "Typically, non top-level members would have defaults filled in, but if they have the clientOptional trait, the defaults should be ignored."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithDefaults"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+                "client_optional_defaults": {}
+            }"""
+        params: {
+            clientOptionalDefaults: {}
+        }
+    }
+])
+
+apply OperationWithDefaults @httpResponseTests([
+    {
+        id: "RailsJsonClientPopulatesDefaultsValuesWhenMissingInResponse"
+        documentation: "Client populates default values when missing in response."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        code: 200
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/json"}
+        body: "{}"
+        params: {
+            defaultString: "hi"
+            defaultBoolean: true
+            defaultList: []
+            defaultDocumentMap: {}
+            defaultDocumentString: "hi"
+            defaultDocumentBoolean: true
+            defaultDocumentList: []
+            defaultTimestamp: 0
+            defaultBlob: "abc"
+            defaultByte: 1
+            defaultShort: 1
+            defaultInteger: 10
+            defaultLong: 100
+            defaultFloat: 1.0
+            defaultDouble: 1.0
+            defaultMap: {}
+            defaultEnum: "FOO"
+            defaultIntEnum: 1
+            emptyString: ""
+            falseBoolean: false
+            emptyBlob: ""
+            zeroByte: 0
+            zeroShort: 0
+            zeroInteger: 0
+            zeroLong: 0
+            zeroFloat: 0.0
+            zeroDouble: 0.0
+        }
+    }
+    {
+        id: "RailsJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse"
+        documentation: "Client ignores default values if member values are present in the response."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        code: 200
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+                "default_string": "bye",
+                "default_boolean": false,
+                "default_list": ["a"],
+                "default_document_map": {"name": "Jack"},
+                "default_document_string": "bye",
+                "default_document_boolean": false,
+                "default_document_list": ["b"],
+                "default_null_document": "notNull",
+                "default_timestamp": "1970-01-01T00:00:01Z",
+                "default_blob": "aGk=",
+                "default_byte": 2,
+                "default_short": 2,
+                "default_integer": 20,
+                "default_long": 200,
+                "default_float": 2.0,
+                "default_double": 2.0,
+                "default_map": {"name": "Jack"},
+                "default_enum": "BAR",
+                "default_int_enum": 2,
+                "empty_string": "foo",
+                "false_boolean": true,
+                "empty_blob": "aGk=",
+                "zero_byte": 1,
+                "zero_short": 1,
+                "zero_integer": 1,
+                "zero_long": 1,
+                "zero_float": 1.0,
+                "zero_double": 1.0
+            }"""
+        params: {
+            defaultString: "bye"
+            defaultBoolean: false
+            defaultList: ["a"]
+            defaultDocumentMap: {name: "Jack"}
+            defaultDocumentString: "bye"
+            defaultDocumentBoolean: false
+            defaultDocumentList: ["b"]
+            defaultNullDocument: "notNull"
+            defaultTimestamp: 1
+            defaultBlob: "hi"
+            defaultByte: 2
+            defaultShort: 2
+            defaultInteger: 20
+            defaultLong: 200
+            defaultFloat: 2.0
+            defaultDouble: 2.0
+            defaultMap: {name: "Jack"}
+            defaultEnum: "BAR"
+            defaultIntEnum: 2
+            emptyString: "foo"
+            falseBoolean: true
+            emptyBlob: "hi"
+            zeroByte: 1
+            zeroShort: 1
+            zeroInteger: 1
+            zeroLong: 1
+            zeroFloat: 1.0
+            zeroDouble: 1.0
+        }
+    }
+])
+
+@http(uri: "/OperationWithDefaults", method: "POST")
+operation OperationWithDefaults {
+    input := {
+        defaults: Defaults
+        clientOptionalDefaults: ClientOptionalDefaults
+        topLevelDefault: String = "hi" // Client should ignore default values in input shape
+        otherTopLevelDefault: Integer = 0
+    }
+
+    output := with [DefaultsMixin] {}
+}
+
+structure Defaults with [DefaultsMixin] {}
+
+structure ClientOptionalDefaults {
+    @clientOptional
+    member: Integer = 0
+}
+
+@mixin
+structure DefaultsMixin {
+    defaultString: String = "hi"
+    defaultBoolean: Boolean = true
+    defaultList: TestStringList = []
+    defaultDocumentMap: Document = {}
+    defaultDocumentString: Document = "hi"
+    defaultDocumentBoolean: Document = true
+    defaultDocumentList: Document = []
+    defaultNullDocument: Document = null
+    defaultTimestamp: Timestamp = 0
+    defaultBlob: Blob = "abc"
+    defaultByte: Byte = 1
+    defaultShort: Short = 1
+    defaultInteger: Integer = 10
+    defaultLong: Long = 100
+    defaultFloat: Float = 1.0
+    defaultDouble: Double = 1.0
+    defaultMap: TestStringMap = {}
+    defaultEnum: TestEnum = "FOO"
+    defaultIntEnum: TestIntEnum = 1
+    emptyString: String = ""
+    falseBoolean: Boolean = false
+    emptyBlob: Blob = ""
+    zeroByte: Byte = 0
+    zeroShort: Short = 0
+    zeroInteger: Integer = 0
+    zeroLong: Long = 0
+    zeroFloat: Float = 0.0
+    zeroDouble: Double = 0.0
+}
+
+list TestStringList {
+    member: String
+}
+
+map TestStringMap {
+    key: String
+    value: String
+}
+
+enum TestEnum {
+    FOO
+    BAR
+    BAZ
+}
+
+intEnum TestIntEnum {
+    ONE = 1
+    TWO = 2
+}

--- a/codegen/smithy-ruby-rails-codegen-test/model/defaults.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/defaults.smithy
@@ -1,5 +1,5 @@
 // This file defines test cases for default value SERDE
-// These tests are taken from: https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/railsJson/defaults.smithy
+// These tests are taken from: https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/awsJson1_0/defaults.smithy
 $version: "2.0"
 
 namespace smithy.ruby.protocoltests.railsjson

--- a/codegen/smithy-ruby-rails-codegen-test/model/defaults.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/defaults.smithy
@@ -148,54 +148,6 @@ apply OperationWithDefaults @httpRequestTests([
             }"""
     }
     {
-        id: "RailsJsonServerPopulatesDefaultsWhenMissingInRequestBody"
-        documentation: "Server populates default values when missing in request body."
-        appliesTo: "server"
-        tags: ["defaults"]
-        protocol: railsJson
-        method: "POST"
-        bodyMediaType: "application/json"
-        uri: "/OperationWithDefaults"
-        headers: {"Content-Type": "application/json"}
-        body: """
-            {
-            "defaults": {}
-            }"""
-        params: {
-            defaults: {
-                defaultString: "hi"
-                defaultBoolean: true
-                defaultList: []
-                defaultDocumentMap: {}
-                defaultDocumentString: "hi"
-                defaultDocumentBoolean: true
-                defaultDocumentList: []
-                defaultTimestamp: 0
-                defaultBlob: "abc"
-                defaultByte: 1
-                defaultShort: 1
-                defaultInteger: 10
-                defaultLong: 100
-                defaultFloat: 1.0
-                defaultDouble: 1.0
-                defaultMap: {}
-                defaultEnum: "FOO"
-                defaultIntEnum: 1
-                emptyString: ""
-                falseBoolean: false
-                emptyBlob: ""
-                zeroByte: 0
-                zeroShort: 0
-                zeroInteger: 0
-                zeroLong: 0
-                zeroFloat: 0.0
-                zeroDouble: 0.0
-            },
-            topLevelDefault: "hi"
-            otherTopLevelDefault: 0
-        }
-    }
-    {
         id: "RailsJsonClientUsesExplicitlyProvidedValuesInTopLevel"
         documentation: "Any time a value is provided for a member in the top level of input, it is used, regardless of if its the default."
         appliesTo: "client"

--- a/codegen/smithy-ruby-rails-codegen-test/model/main.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/main.smithy
@@ -117,5 +117,6 @@ service RailsJson {
 
         // defaults
         OperationWithDefaults
+        OperationWithNestedStructure
     ]
 }

--- a/codegen/smithy-ruby-rails-codegen-test/model/main.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/main.smithy
@@ -114,5 +114,8 @@ service RailsJson {
 
         // requestCompression trait tests
         PutWithContentEncoding
+
+        // defaults
+        OperationWithDefaults
     ]
 }

--- a/codegen/smithy-ruby-rails-codegen-test/model/nested-defaults.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/nested-defaults.smithy
@@ -1,5 +1,5 @@
 // defines test cases for nested defaults
-// tests taken from: https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/railsJson/nestedDefaults.smithy
+// tests taken from: https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/awsJson1_0/nestedDefaults.smithy
 $version: "2.0"
 
 namespace smithy.ruby.protocoltests.railsjson

--- a/codegen/smithy-ruby-rails-codegen-test/model/nested-defaults.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/nested-defaults.smithy
@@ -1,0 +1,234 @@
+// defines test cases for nested defaults
+// tests taken from: https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/railsJson/nestedDefaults.smithy
+$version: "2.0"
+
+namespace smithy.ruby.protocoltests.railsjson
+
+use smithy.ruby.protocols#railsJson
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply OperationWithNestedStructure @httpRequestTests([
+    {
+        id: "RailsJsonClientPopulatesNestedDefaultValuesWhenMissing"
+        documentation: "Client populates nested default values when missing."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        method: "POST"
+        bodyMediaType: "application/json"
+        uri: "/OperationWithNestedStructure"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+                "top_level": {
+                    "dialog": {
+                        "language": "en",
+                        "greeting": "hi"
+                    },
+                    "dialog_list": [
+                        {
+                            "greeting": "hi"
+                        },
+                        {
+                            "greeting": "hi",
+                            "farewell": {
+                                "phrase": "bye"
+                            }
+                        },
+                        {
+                            "language": "it",
+                            "greeting": "ciao",
+                            "farewell": {
+                                "phrase": "arrivederci"
+                            }
+                        }
+                    ],
+                    "dialog_map": {
+                        "emptyDialog": {
+                            "greeting": "hi"
+                        },
+                        "partialEmptyDialog": {
+                            "language": "en",
+                            "greeting": "hi",
+                            "farewell": {
+                                "phrase": "bye"
+                            }
+                        },
+                        "nonEmptyDialog": {
+                            "greeting": "konnichiwa",
+                            "farewell": {
+                                "phrase": "sayonara"
+                            }
+                        }
+                    }
+                }
+            }"""
+        params: {
+            "topLevel": {
+                "dialog": {
+                    "language": "en"
+                },
+                "dialogList": [
+                    {
+                    },
+                    {
+                        "farewell": {}
+                    },
+                    {
+                        "language": "it",
+                        "greeting": "ciao",
+                        "farewell": {
+                            "phrase": "arrivederci"
+                        }
+                    }
+                ],
+                "dialogMap": {
+                    "emptyDialog": {
+                    },
+                    "partialEmptyDialog": {
+                        "language": "en",
+                        "farewell": {}
+                    },
+                    "nonEmptyDialog": {
+                        "greeting": "konnichiwa",
+                        "farewell": {
+                            "phrase": "sayonara"
+                        }
+                    }
+                }
+            }
+        }
+    }
+])
+
+apply OperationWithNestedStructure @httpResponseTests([
+    {
+        id: "RailsJsonClientPopulatesNestedDefaultsWhenMissingInResponseBody"
+        documentation: "Client populates nested default values when missing in response body."
+        appliesTo: "client"
+        tags: ["defaults"]
+        protocol: railsJson
+        code: 200
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/json"}
+        body: """
+            {
+                "dialog": {
+                    "language": "en"
+                },
+                "dialog_list": [
+                    {
+                    },
+                    {
+                        "farewell": {}
+                    },
+                    {
+                        "language": "it",
+                        "greeting": "ciao",
+                        "farewell": {
+                            "phrase": "arrivederci"
+                        }
+                    }
+                ],
+                "dialog_map": {
+                    "emptyDialog": {
+                    },
+                    "partialEmptyDialog": {
+                        "language": "en",
+                        "farewell": {}
+                    },
+                    "nonEmptyDialog": {
+                        "greeting": "konnichiwa",
+                        "farewell": {
+                            "phrase": "sayonara"
+                        }
+                    }
+                }
+            }"""
+        params: {
+            "dialog": {
+                "language": "en"
+                "greeting": "hi",
+            }
+            "dialogList": [
+                {
+                    "greeting": "hi",
+                },
+                {
+                    "greeting": "hi",
+                    "farewell": {
+                        "phrase": "bye",
+                    }
+                },
+                {
+                    "language": "it",
+                    "greeting": "ciao",
+                    "farewell": {
+                        "phrase": "arrivederci"
+                    }
+                }
+            ],
+            "dialogMap": {
+                "emptyDialog": {
+                    "greeting": "hi",
+                },
+                "partialEmptyDialog": {
+                    "language": "en",
+                    "greeting": "hi",
+                    "farewell": {
+                        "phrase": "bye",
+                    }
+                },
+                "nonEmptyDialog": {
+                    "greeting": "konnichiwa",
+                    "farewell": {
+                        "phrase": "sayonara"
+                    }
+                }
+            }
+        }
+    }
+])
+
+@http(uri: "/OperationWithNestedStructure", method: "POST")
+operation OperationWithNestedStructure {
+    input := {
+        @required
+        topLevel: TopLevel
+    }
+
+    output := with [NestedDefaultsMixin] {
+    }
+}
+
+structure TopLevel with [NestedDefaultsMixin] {
+
+}
+
+@mixin
+structure NestedDefaultsMixin {
+    @required
+    dialog: Dialog
+    dialogList: DialogList = []
+    dialogMap: DialogMap = {}
+}
+
+structure Dialog {
+    language: String
+    greeting: String = "hi"
+    farewell: Farewell
+}
+
+structure Farewell {
+    phrase: String = "bye"
+}
+
+list DialogList {
+    member: Dialog
+}
+
+map DialogMap {
+    key: String
+    value: Dialog
+}

--- a/hearth/lib/hearth/structure.rb
+++ b/hearth/lib/hearth/structure.rb
@@ -3,6 +3,16 @@
 module Hearth
   # A module mixed into Structs that provides utility methods.
   module Structure
+
+    def initialize(options = {})
+      if respond_to?(:_defaults, true)
+        _defaults.each do |k,v|
+          options[k] = v unless options.include?(k)
+        end
+      end
+      super(options)
+    end
+
     # Deeply converts the Struct into a hash. Structure members that
     # are `nil` are omitted from the resultant hash.
     #

--- a/hearth/lib/hearth/structure.rb
+++ b/hearth/lib/hearth/structure.rb
@@ -3,10 +3,9 @@
 module Hearth
   # A module mixed into Structs that provides utility methods.
   module Structure
-
     def initialize(options = {})
       if respond_to?(:_defaults, true)
-        _defaults.each do |k,v|
+        _defaults.each do |k, v|
           options[k] = v unless options.include?(k)
         end
       end

--- a/hearth/lib/hearth/structure.rb
+++ b/hearth/lib/hearth/structure.rb
@@ -3,6 +3,8 @@
 module Hearth
   # A module mixed into Structs that provides utility methods.
   module Structure
+    # Initializes the structure with the given options. If a member is
+    # not provided, the default value is used.
     def initialize(options = {})
       if respond_to?(:_defaults, true)
         _defaults.each do |k, v|

--- a/hearth/spec/hearth/structure_spec.rb
+++ b/hearth/spec/hearth/structure_spec.rb
@@ -24,6 +24,23 @@ module Hearth
       end
     end
 
+    let(:struct_with_default) do
+      Struct.new(
+        :value_no_default,
+        :value_with_default,
+        keyword_init: true
+      ) do
+        include Hearth::Structure
+
+        private
+        def _defaults
+          {
+            value_with_default: "default"
+          }
+        end
+      end
+    end
+
     subject do
       struct.new(
         struct_value: struct.new(value: 'foo'),
@@ -37,6 +54,19 @@ module Hearth
         some_object: Object.new
       )
     end
+
+      describe '#initialize' do
+        it 'initializes with defaults' do
+          obj = struct_with_default.new
+          expect(obj.value_with_default).to eq("default")
+          expect(obj.value_no_default).to be_nil
+        end
+
+        it 'initializes with user provided values' do
+          obj = struct_with_default.new(value_with_default: "custom")
+          expect(obj.value_with_default).to eq("custom")
+        end
+      end
 
     describe '#to_hash' do
       it 'serializes nested structs to a hash' do

--- a/hearth/spec/hearth/structure_spec.rb
+++ b/hearth/spec/hearth/structure_spec.rb
@@ -33,9 +33,10 @@ module Hearth
         include Hearth::Structure
 
         private
+
         def _defaults
           {
-            value_with_default: "default"
+            value_with_default: 'default'
           }
         end
       end
@@ -55,18 +56,18 @@ module Hearth
       )
     end
 
-      describe '#initialize' do
-        it 'initializes with defaults' do
-          obj = struct_with_default.new
-          expect(obj.value_with_default).to eq("default")
-          expect(obj.value_no_default).to be_nil
-        end
-
-        it 'initializes with user provided values' do
-          obj = struct_with_default.new(value_with_default: "custom")
-          expect(obj.value_with_default).to eq("custom")
-        end
+    describe '#initialize' do
+      it 'initializes with defaults' do
+        obj = struct_with_default.new
+        expect(obj.value_with_default).to eq('default')
+        expect(obj.value_no_default).to be_nil
       end
+
+      it 'initializes with user provided values' do
+        obj = struct_with_default.new(value_with_default: 'custom')
+        expect(obj.value_with_default).to eq('custom')
+      end
+    end
 
     describe '#to_hash' do
       it 'serializes nested structs to a hash' do

--- a/hearth/spec/hearth/structure_spec.rb
+++ b/hearth/spec/hearth/structure_spec.rb
@@ -18,16 +18,7 @@ module Hearth
         :value,
         :union_value,
         :some_object,
-        keyword_init: true
-      ) do
-        include Hearth::Structure
-      end
-    end
-
-    let(:struct_with_default) do
-      Struct.new(
-        :value_no_default,
-        :value_with_default,
+        :default_value,
         keyword_init: true
       ) do
         include Hearth::Structure
@@ -36,7 +27,7 @@ module Hearth
 
         def _defaults
           {
-            value_with_default: 'default'
+            default_value: 'default'
           }
         end
       end
@@ -58,31 +49,25 @@ module Hearth
 
     describe '#initialize' do
       it 'initializes with defaults' do
-        obj = struct_with_default.new
-        expect(obj.value_with_default).to eq('default')
-        expect(obj.value_no_default).to be_nil
-      end
-
-      it 'initializes with user provided values' do
-        obj = struct_with_default.new(value_with_default: 'custom')
-        expect(obj.value_with_default).to eq('custom')
+        expect(subject.default_value).to eq('default')
       end
     end
 
     describe '#to_hash' do
       it 'serializes nested structs to a hash' do
         expected = {
-          struct_value: { value: 'foo' },
+          struct_value: { value: 'foo', default_value: 'default' },
           array_value: [
-            { value: 'foo' },
-            { value: 'bar' }
+            { value: 'foo', default_value: 'default' },
+            { value: 'bar', default_value: 'default' }
           ],
           hash_value: {
-            key: { value: 'value' }
+            key: { value: 'value', default_value: 'default' }
           },
           value: 'value',
           union_value: { string_value: 'union' },
-          some_object: subject.some_object
+          some_object: subject.some_object,
+          default_value: 'default'
         }
         expect(subject.to_h).to eq expected
       end


### PR DESCRIPTION
*Description of changes:*
Implements defaults as values in type initialize following the rules for non-authoritative (client) generators.

Smithy documentation on Defaults:

* [Structure Member Optionality](https://smithy.io/2.0/spec/aggregate-types.html#structure-member-optionality) - this defines whether the type of structure members should be Optional (for languages which have this).  It does discuss default values, but type optionality is different than default values.
* [Default Trait](https://smithy.io/2.0/spec/type-refinement-traits.html#default-trait) 
* [Default Trait serialization rules](https://smithy.io/2.0/spec/type-refinement-traits.html#default-value-serialization)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
