### PR TITLE
Use bundler-cache in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,8 @@ jobs:
         ruby: ['3.0', 3.1, 3.2, 3.3]
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -34,11 +36,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - uses: actions/checkout@v3
-
-      - name: Install gems
-        run: bundle install
+          bundler-cache: true
 
       - name: Build SDK
         run: bundle exec rake codegen:build

--- a/.github/workflows/codegen_ci.yml
+++ b/.github/workflows/codegen_ci.yml
@@ -51,20 +51,18 @@ jobs:
         ruby: ['3.0', 3.1, 3.2, 3.3]
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.java_version }}
-
-      - uses: actions/checkout@v2
-
-      - name: Install gems
-        run: bundle install
 
       - name: Build SDK
         run: bundle exec rake codegen:build
@@ -79,15 +77,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
-
-      - uses: actions/checkout@v2
-
-      - name: Install gems
-        run: bundle install
+          bundler-cache: true
 
       - name: Rubocop
         run: bundle exec rake rubocop:codegen

--- a/.github/workflows/downstream_ci.yml
+++ b/.github/workflows/downstream_ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -28,11 +30,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
-
-      - uses: actions/checkout@v2
-
-      - name: Install gems
-        run: bundle install
+          bundler-cache: true
 
       - name: publish smithy-ruby to maven local
         run: bundle exec rake codegen:publish-local

--- a/.github/workflows/hearth_ci.yml
+++ b/.github/workflows/hearth_ci.yml
@@ -21,15 +21,13 @@ jobs:
         ruby: ['3.0', 3.1, 3.2, 3.3]
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - uses: actions/checkout@v2
-
-      - name: Install gems
-        run: bundle install
+          bundler-cache: true
 
       - name: Unit tests
         run: bundle exec rake test:hearth
@@ -38,15 +36,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
-
-      - uses: actions/checkout@v2
-
-      - name: Install gems
-        run: bundle install
+          bundler-cache: true
 
       - name: Steep Check
         run: bundle exec rake steep:hearth
@@ -58,15 +54,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
-
-      - uses: actions/checkout@v2
-
-      - name: Install gems
-        run: bundle install
+          bundler-cache: true
 
       - name: Rubocop
         run: bundle exec rake rubocop:hearth


### PR DESCRIPTION

*Description of changes:*
Uses the `bundler-cache` option for [setup-ruby](https://github.com/ruby/setup-ruby).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
