### PR TITLE
Add config to interceptors

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -84,17 +84,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :all_query_string_types,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#all_query_string_types] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#all_query_string_types] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#all_query_string_types] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#all_query_string_types] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#all_query_string_types] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#all_query_string_types] #{output.data}")
       output
     end
 
@@ -123,17 +122,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :constant_and_variable_query_string,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#constant_and_variable_query_string] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#constant_and_variable_query_string] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#constant_and_variable_query_string] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#constant_and_variable_query_string] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#constant_and_variable_query_string] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#constant_and_variable_query_string] #{output.data}")
       output
     end
 
@@ -162,17 +160,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :constant_query_string,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#constant_query_string] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#constant_query_string] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#constant_query_string] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#constant_query_string] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#constant_query_string] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#constant_query_string] #{output.data}")
       output
     end
 
@@ -197,17 +194,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :datetime_offsets,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#datetime_offsets] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#datetime_offsets] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#datetime_offsets] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#datetime_offsets] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#datetime_offsets] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#datetime_offsets] #{output.data}")
       output
     end
 
@@ -243,17 +239,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :document_type,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#document_type] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#document_type] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#document_type] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#document_type] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#document_type] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#document_type] #{output.data}")
       output
     end
 
@@ -290,17 +285,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :document_type_as_map_value,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_map_value] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_map_value] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#document_type_as_map_value] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#document_type_as_map_value] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_map_value] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_map_value] #{output.data}")
       output
     end
 
@@ -334,17 +328,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :document_type_as_payload,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_payload] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_payload] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#document_type_as_payload] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#document_type_as_payload] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_payload] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#document_type_as_payload] #{output.data}")
       output
     end
 
@@ -371,17 +364,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :empty_input_and_empty_output,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#empty_input_and_empty_output] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#empty_input_and_empty_output] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#empty_input_and_empty_output] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#empty_input_and_empty_output] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#empty_input_and_empty_output] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#empty_input_and_empty_output] #{output.data}")
       output
     end
 
@@ -404,17 +396,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :endpoint_operation,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.data}")
       output
     end
 
@@ -439,17 +430,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :endpoint_with_host_label_operation,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.data}")
       output
     end
 
@@ -474,17 +464,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :fractional_seconds,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#fractional_seconds] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#fractional_seconds] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#fractional_seconds] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#fractional_seconds] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#fractional_seconds] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#fractional_seconds] #{output.data}")
       output
     end
 
@@ -517,17 +506,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :greeting_with_errors,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#greeting_with_errors] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#greeting_with_errors] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#greeting_with_errors] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#greeting_with_errors] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#greeting_with_errors] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#greeting_with_errors] #{output.data}")
       output
     end
 
@@ -550,17 +538,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :host_with_path_operation,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#host_with_path_operation] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#host_with_path_operation] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#host_with_path_operation] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#host_with_path_operation] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#host_with_path_operation] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#host_with_path_operation] #{output.data}")
       output
     end
 
@@ -587,17 +574,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_checksum_required,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_checksum_required] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_checksum_required] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_checksum_required] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_checksum_required] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_checksum_required] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_checksum_required] #{output.data}")
       output
     end
 
@@ -623,17 +609,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_enum_payload,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_enum_payload] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_enum_payload] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_enum_payload] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_enum_payload] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_enum_payload] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_enum_payload] #{output.data}")
       output
     end
 
@@ -665,17 +650,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_payload_traits,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_traits] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_traits] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits] #{output.data}")
       output
     end
 
@@ -705,17 +689,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_payload_traits_with_media_type,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits_with_media_type] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits_with_media_type] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_traits_with_media_type] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_traits_with_media_type] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits_with_media_type] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_traits_with_media_type] #{output.data}")
       output
     end
 
@@ -750,17 +733,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_payload_with_structure,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_structure] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_structure] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_with_structure] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_with_structure] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_structure] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_structure] #{output.data}")
       output
     end
 
@@ -791,17 +773,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_payload_with_union,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_union] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_union] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_with_union] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_payload_with_union] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_union] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_payload_with_union] #{output.data}")
       output
     end
 
@@ -834,17 +815,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_prefix_headers,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_prefix_headers] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_prefix_headers] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers] #{output.data}")
       output
     end
 
@@ -870,17 +850,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_prefix_headers_in_response,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers_in_response] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers_in_response] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_prefix_headers_in_response] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_prefix_headers_in_response] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers_in_response] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_prefix_headers_in_response] #{output.data}")
       output
     end
 
@@ -906,17 +885,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_request_with_float_labels,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_float_labels] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_float_labels] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_float_labels] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_float_labels] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_float_labels] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_float_labels] #{output.data}")
       output
     end
 
@@ -942,17 +920,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_request_with_greedy_label_in_path,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_greedy_label_in_path] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_greedy_label_in_path] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_greedy_label_in_path] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_greedy_label_in_path] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_greedy_label_in_path] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_greedy_label_in_path] #{output.data}")
       output
     end
 
@@ -986,17 +963,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_request_with_labels,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_labels] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_labels] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels] #{output.data}")
       output
     end
 
@@ -1029,17 +1005,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_request_with_labels_and_timestamp_format,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels_and_timestamp_format] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels_and_timestamp_format] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_labels_and_timestamp_format] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_labels_and_timestamp_format] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels_and_timestamp_format] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_labels_and_timestamp_format] #{output.data}")
       output
     end
 
@@ -1064,17 +1039,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_request_with_regex_literal,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_regex_literal] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_regex_literal] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_regex_literal] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_request_with_regex_literal] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_regex_literal] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_request_with_regex_literal] #{output.data}")
       output
     end
 
@@ -1098,17 +1072,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_response_code,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_response_code] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_response_code] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_response_code] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_response_code] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_response_code] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_response_code] #{output.data}")
       output
     end
 
@@ -1134,17 +1107,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_string_payload,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_string_payload] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_string_payload] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_string_payload] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_string_payload] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_string_payload] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_string_payload] #{output.data}")
       output
     end
 
@@ -1171,17 +1143,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :ignore_query_params_in_response,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#ignore_query_params_in_response] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#ignore_query_params_in_response] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#ignore_query_params_in_response] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#ignore_query_params_in_response] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#ignore_query_params_in_response] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#ignore_query_params_in_response] #{output.data}")
       output
     end
 
@@ -1264,17 +1235,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :input_and_output_with_headers,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#input_and_output_with_headers] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#input_and_output_with_headers] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#input_and_output_with_headers] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#input_and_output_with_headers] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#input_and_output_with_headers] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#input_and_output_with_headers] #{output.data}")
       output
     end
 
@@ -1301,17 +1271,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_blobs,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_blobs] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_blobs] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_blobs] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_blobs] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_blobs] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_blobs] #{output.data}")
       output
     end
 
@@ -1357,17 +1326,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_enums,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_enums] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_enums] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_enums] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_enums] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_enums] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_enums] #{output.data}")
       output
     end
 
@@ -1413,17 +1381,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_int_enums,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_int_enums] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_int_enums] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_int_enums] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_int_enums] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_int_enums] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_int_enums] #{output.data}")
       output
     end
 
@@ -1500,17 +1467,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_lists,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_lists] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_lists] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_lists] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_lists] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_lists] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_lists] #{output.data}")
       output
     end
 
@@ -1566,17 +1532,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_maps,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_maps] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_maps] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_maps] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_maps] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_maps] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_maps] #{output.data}")
       output
     end
 
@@ -1617,17 +1582,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_timestamps,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_timestamps] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_timestamps] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_timestamps] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_timestamps] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_timestamps] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_timestamps] #{output.data}")
       output
     end
 
@@ -1688,17 +1652,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :json_unions,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_unions] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_unions] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#json_unions] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#json_unions] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#json_unions] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#json_unions] #{output.data}")
       output
     end
 
@@ -1725,17 +1688,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :media_type_header,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#media_type_header] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#media_type_header] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#media_type_header] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#media_type_header] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#media_type_header] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#media_type_header] #{output.data}")
       output
     end
 
@@ -1761,17 +1723,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :no_input_and_no_output,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_no_output] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_no_output] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#no_input_and_no_output] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#no_input_and_no_output] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_no_output] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_no_output] #{output.data}")
       output
     end
 
@@ -1798,17 +1759,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :no_input_and_output,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_output] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_output] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#no_input_and_output] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#no_input_and_output] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_output] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#no_input_and_output] #{output.data}")
       output
     end
 
@@ -1843,17 +1803,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :null_and_empty_headers_client,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_client] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_client] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_client] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_client] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_client] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_client] #{output.data}")
       output
     end
 
@@ -1888,17 +1847,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :null_and_empty_headers_server,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_server] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_server] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_server] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_server] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_server] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#null_and_empty_headers_server] #{output.data}")
       output
     end
 
@@ -1925,17 +1883,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :omits_null_serializes_empty_string,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#omits_null_serializes_empty_string] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#omits_null_serializes_empty_string] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#omits_null_serializes_empty_string] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#omits_null_serializes_empty_string] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#omits_null_serializes_empty_string] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#omits_null_serializes_empty_string] #{output.data}")
       output
     end
 
@@ -1984,17 +1941,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :omits_serializing_empty_lists,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#omits_serializing_empty_lists] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#omits_serializing_empty_lists] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#omits_serializing_empty_lists] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#omits_serializing_empty_lists] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#omits_serializing_empty_lists] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#omits_serializing_empty_lists] #{output.data}")
       output
     end
 
@@ -2090,17 +2046,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :operation_with_defaults,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_defaults] #{output.data}")
       output
     end
 
@@ -2140,17 +2095,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :operation_with_nested_structure,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#operation_with_nested_structure] #{output.data}")
       output
     end
 
@@ -2181,17 +2135,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :post_player_action,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#post_player_action] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#post_player_action] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#post_player_action] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#post_player_action] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#post_player_action] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#post_player_action] #{output.data}")
       output
     end
 
@@ -2226,17 +2179,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :post_union_with_json_name,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#post_union_with_json_name] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#post_union_with_json_name] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#post_union_with_json_name] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#post_union_with_json_name] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#post_union_with_json_name] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#post_union_with_json_name] #{output.data}")
       output
     end
 
@@ -2262,17 +2214,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :put_with_content_encoding,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#put_with_content_encoding] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#put_with_content_encoding] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#put_with_content_encoding] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#put_with_content_encoding] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#put_with_content_encoding] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#put_with_content_encoding] #{output.data}")
       output
     end
 
@@ -2299,17 +2250,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :query_idempotency_token_auto_fill,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#query_idempotency_token_auto_fill] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#query_idempotency_token_auto_fill] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#query_idempotency_token_auto_fill] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#query_idempotency_token_auto_fill] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#query_idempotency_token_auto_fill] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#query_idempotency_token_auto_fill] #{output.data}")
       output
     end
 
@@ -2339,17 +2289,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :query_params_as_string_list_map,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#query_params_as_string_list_map] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#query_params_as_string_list_map] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#query_params_as_string_list_map] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#query_params_as_string_list_map] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#query_params_as_string_list_map] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#query_params_as_string_list_map] #{output.data}")
       output
     end
 
@@ -2377,17 +2326,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :query_precedence,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#query_precedence] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#query_precedence] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#query_precedence] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#query_precedence] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#query_precedence] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#query_precedence] #{output.data}")
       output
     end
 
@@ -2423,17 +2371,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :recursive_shapes,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#recursive_shapes] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#recursive_shapes] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#recursive_shapes] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#recursive_shapes] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#recursive_shapes] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#recursive_shapes] #{output.data}")
       output
     end
 
@@ -2477,17 +2424,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :simple_scalar_properties,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#simple_scalar_properties] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#simple_scalar_properties] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#simple_scalar_properties] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#simple_scalar_properties] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#simple_scalar_properties] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#simple_scalar_properties] #{output.data}")
       output
     end
 
@@ -2516,17 +2462,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :sparse_json_lists,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_lists] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_lists] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#sparse_json_lists] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#sparse_json_lists] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_lists] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_lists] #{output.data}")
       output
     end
 
@@ -2582,17 +2527,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :sparse_json_maps,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_maps] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_maps] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#sparse_json_maps] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#sparse_json_maps] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_maps] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#sparse_json_maps] #{output.data}")
       output
     end
 
@@ -2624,17 +2568,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :streaming_traits,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_traits] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_traits] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits] #{output.data}")
       output
     end
 
@@ -2665,17 +2608,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :streaming_traits_require_length,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_require_length] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_require_length] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_traits_require_length] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_traits_require_length] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_require_length] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_require_length] #{output.data}")
       output
     end
 
@@ -2707,17 +2649,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :streaming_traits_with_media_type,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_with_media_type] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_with_media_type] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_traits_with_media_type] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_traits_with_media_type] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_with_media_type] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_traits_with_media_type] #{output.data}")
       output
     end
 
@@ -2754,17 +2695,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :test_body_structure,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_body_structure] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_body_structure] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#test_body_structure] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#test_body_structure] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_body_structure] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_body_structure] #{output.data}")
       output
     end
 
@@ -2796,17 +2736,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :test_no_payload,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_no_payload] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_no_payload] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#test_no_payload] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#test_no_payload] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_no_payload] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_no_payload] #{output.data}")
       output
     end
 
@@ -2842,17 +2781,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :test_payload_blob,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_blob] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_blob] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#test_payload_blob] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#test_payload_blob] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_blob] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_blob] #{output.data}")
       output
     end
 
@@ -2888,17 +2826,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :test_payload_structure,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_structure] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_structure] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#test_payload_structure] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#test_payload_structure] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_structure] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#test_payload_structure] #{output.data}")
       output
     end
 
@@ -2937,17 +2874,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :timestamp_format_headers,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#timestamp_format_headers] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#timestamp_format_headers] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#timestamp_format_headers] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#timestamp_format_headers] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#timestamp_format_headers] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#timestamp_format_headers] #{output.data}")
       output
     end
 
@@ -2971,17 +2907,16 @@ module RailsJson
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :unit_input_and_output,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#unit_input_and_output] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#unit_input_and_output] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#unit_input_and_output] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#unit_input_and_output] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#unit_input_and_output] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#unit_input_and_output] #{output.data}")
       output
     end
   end

--- a/codegen/projections/rails_json/sig/rails_json/client.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/client.rbs
@@ -21,7 +21,7 @@ module RailsJson
         ?endpoint: String,
         ?endpoint_resolver: Hearth::_EndpointResolver[Endpoint::Params],
         ?http_client: Hearth::HTTP::Client,
-        ?interceptors: Hearth::InterceptorList,
+        ?interceptors: Hearth::InterceptorList[Config],
         ?logger: Logger,
         ?plugins: Hearth::PluginList[Config],
         ?request_min_compression_size_bytes: Integer,

--- a/codegen/projections/rails_json/sig/rails_json/config.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/config.rbs
@@ -9,7 +9,7 @@ module RailsJson
     attr_accessor endpoint (): String
     attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]
     attr_accessor http_client (): Hearth::HTTP::Client
-    attr_accessor interceptors (): Hearth::InterceptorList
+    attr_accessor interceptors (): Hearth::InterceptorList[Config]
     attr_accessor logger (): Logger
     attr_accessor plugins (): Hearth::PluginList[Config]
     attr_accessor request_min_compression_size_bytes (): Integer

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -60,17 +60,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :custom_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#custom_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#custom_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#custom_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#custom_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#custom_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#custom_auth] #{output.data}")
       output
     end
 
@@ -93,17 +92,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :dataplane_endpoint,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#dataplane_endpoint] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#dataplane_endpoint] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#dataplane_endpoint] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#dataplane_endpoint] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#dataplane_endpoint] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#dataplane_endpoint] #{output.data}")
       output
     end
 
@@ -180,17 +178,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :defaults_test,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#defaults_test] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#defaults_test] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#defaults_test] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#defaults_test] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#defaults_test] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#defaults_test] #{output.data}")
       output
     end
 
@@ -213,17 +210,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :endpoint_operation,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_operation] #{output.data}")
       output
     end
 
@@ -248,17 +244,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :endpoint_with_host_label_operation,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#endpoint_with_host_label_operation] #{output.data}")
       output
     end
 
@@ -281,17 +276,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_api_key_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_api_key_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_api_key_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_api_key_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_api_key_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_api_key_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_api_key_auth] #{output.data}")
       output
     end
 
@@ -314,17 +308,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_basic_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_basic_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_basic_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_basic_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_basic_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_basic_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_basic_auth] #{output.data}")
       output
     end
 
@@ -347,17 +340,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_bearer_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_bearer_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_bearer_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_bearer_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_bearer_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_bearer_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_bearer_auth] #{output.data}")
       output
     end
 
@@ -380,17 +372,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :http_digest_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_digest_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_digest_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#http_digest_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#http_digest_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#http_digest_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#http_digest_auth] #{output.data}")
       output
     end
 
@@ -555,17 +546,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :kitchen_sink,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#kitchen_sink] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#kitchen_sink] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#kitchen_sink] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#kitchen_sink] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#kitchen_sink] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#kitchen_sink] #{output.data}")
       output
     end
 
@@ -592,17 +582,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :mixin_test,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#mixin_test] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#mixin_test] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#mixin_test] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#mixin_test] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#mixin_test] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#mixin_test] #{output.data}")
       output
     end
 
@@ -625,17 +614,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :no_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#no_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#no_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#no_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#no_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#no_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#no_auth] #{output.data}")
       output
     end
 
@@ -658,17 +646,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :optional_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#optional_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#optional_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#optional_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#optional_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#optional_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#optional_auth] #{output.data}")
       output
     end
 
@@ -691,17 +678,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :ordered_auth,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#ordered_auth] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#ordered_auth] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#ordered_auth] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#ordered_auth] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#ordered_auth] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#ordered_auth] #{output.data}")
       output
     end
 
@@ -729,17 +715,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :paginators_test,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#paginators_test] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#paginators_test] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test] #{output.data}")
       output
     end
 
@@ -767,17 +752,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :paginators_test_with_items,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test_with_items] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test_with_items] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#paginators_test_with_items] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#paginators_test_with_items] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test_with_items] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#paginators_test_with_items] #{output.data}")
       output
     end
 
@@ -800,17 +784,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :relative_middleware,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#relative_middleware] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#relative_middleware] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#relative_middleware] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#relative_middleware] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#relative_middleware] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#relative_middleware] #{output.data}")
       output
     end
 
@@ -835,17 +818,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :request_compression,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#request_compression] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#request_compression] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression] #{output.data}")
       output
     end
 
@@ -870,17 +852,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :request_compression_streaming,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression_streaming] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression_streaming] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#request_compression_streaming] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#request_compression_streaming] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression_streaming] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#request_compression_streaming] #{output.data}")
       output
     end
 
@@ -905,17 +886,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :resource_endpoint,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#resource_endpoint] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#resource_endpoint] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#resource_endpoint] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#resource_endpoint] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#resource_endpoint] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#resource_endpoint] #{output.data}")
       output
     end
 
@@ -941,17 +921,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :streaming,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#streaming] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#streaming] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming] #{output.data}")
       output
     end
 
@@ -976,17 +955,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :streaming_with_length,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_with_length] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_with_length] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_with_length] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#streaming_with_length] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_with_length] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#streaming_with_length] #{output.data}")
       output
     end
 
@@ -1012,17 +990,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :waiters_test,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#waiters_test] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#waiters_test] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#waiters_test] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#waiters_test] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#waiters_test] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#waiters_test] #{output.data}")
       output
     end
 
@@ -1051,17 +1028,16 @@ module WhiteLabel
       context = Hearth::Context.new(
         request: Hearth::HTTP::Request.new(uri: URI('')),
         response: Hearth::HTTP::Response.new(body: response_body),
-        logger: config.logger,
+        config: config,
         operation_name: :operation____paginators_test_with_bad_names,
-        interceptors: config.interceptors
       )
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation____paginators_test_with_bad_names] params: #{params}, options: #{options}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#operation____paginators_test_with_bad_names] params: #{params}, options: #{options}")
       output = stack.run(input, context)
       if output.error
-        context.logger.error("[#{context.invocation_id}] [#{self.class}#operation____paginators_test_with_bad_names] #{output.error} (#{output.error.class})")
+        context.config.logger.error("[#{context.invocation_id}] [#{self.class}#operation____paginators_test_with_bad_names] #{output.error} (#{output.error.class})")
         raise output.error
       end
-      context.logger.info("[#{context.invocation_id}] [#{self.class}#operation____paginators_test_with_bad_names] #{output.data}")
+      context.config.logger.info("[#{context.invocation_id}] [#{self.class}#operation____paginators_test_with_bad_names] #{output.data}")
       output
     end
   end

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -25,7 +25,7 @@ module WhiteLabel
         ?http_client: Hearth::HTTP::Client,
         ?http_custom_key_provider: untyped,
         ?http_login_provider: Hearth::IdentityProvider,
-        ?interceptors: Hearth::InterceptorList,
+        ?interceptors: Hearth::InterceptorList[Config],
         ?logger: Logger,
         ?plugins: Hearth::PluginList[Config],
         ?request_min_compression_size_bytes: Integer,

--- a/codegen/projections/white_label/sig/white_label/config.rbs
+++ b/codegen/projections/white_label/sig/white_label/config.rbs
@@ -13,7 +13,7 @@ module WhiteLabel
     attr_accessor http_client (): Hearth::HTTP::Client
     attr_accessor http_custom_key_provider (): untyped
     attr_accessor http_login_provider (): Hearth::IdentityProvider
-    attr_accessor interceptors (): Hearth::InterceptorList
+    attr_accessor interceptors (): Hearth::InterceptorList[Config]
     attr_accessor logger (): Logger
     attr_accessor plugins (): Hearth::PluginList[Config]
     attr_accessor request_min_compression_size_bytes (): Integer

--- a/codegen/projections/white_label/spec/client_spec.rb
+++ b/codegen/projections/white_label/spec/client_spec.rb
@@ -70,10 +70,14 @@ module WhiteLabel
       end
 
       it 'uses logger' do
-        expect(Hearth::Context)
-          .to receive(:new)
-          .with(hash_including(logger: client.config.logger))
-          .and_call_original
+        expect(client.config.logger)
+          .to receive(:debug)
+          .with(anything)
+          .at_least(:once)
+        expect(client.config.logger)
+          .to receive(:info)
+          .with(anything)
+          .at_least(:once)
 
         client.kitchen_sink
       end
@@ -136,10 +140,8 @@ module WhiteLabel
 
         it 'uses logger from options' do
           logger = Logger.new(IO::NULL, level: :debug)
-          expect(Hearth::Context)
-            .to receive(:new)
-            .with(hash_including(logger: logger))
-            .and_call_original
+          expect(logger).to receive(:debug).with(anything).at_least(:once)
+          expect(logger).to receive(:info).with(anything).at_least(:once)
 
           client.kitchen_sink({}, logger: logger)
         end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
@@ -70,10 +70,14 @@ module WhiteLabel
       end
 
       it 'uses logger' do
-        expect(Hearth::Context)
-          .to receive(:new)
-          .with(hash_including(logger: client.config.logger))
-          .and_call_original
+        expect(client.config.logger)
+          .to receive(:debug)
+          .with(anything)
+          .at_least(:once)
+        expect(client.config.logger)
+          .to receive(:info)
+          .with(anything)
+          .at_least(:once)
 
         client.kitchen_sink
       end
@@ -136,10 +140,8 @@ module WhiteLabel
 
         it 'uses logger from options' do
           logger = Logger.new(IO::NULL, level: :debug)
-          expect(Hearth::Context)
-            .to receive(:new)
-            .with(hash_including(logger: logger))
-            .and_call_original
+          expect(logger).to receive(:debug).with(anything).at_least(:once)
+          expect(logger).to receive(:info).with(anything).at_least(:once)
 
           client.kitchen_sink({}, logger: logger)
         end

--- a/codegen/smithy-ruby-codegen/CHANGELOG.md
+++ b/codegen/smithy-ruby-codegen/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased Changes
 * Issue - Resolve `ClientConfig` from integrations first.
 * Issue - Rename config `defaults` method to avoid name conflicts.
 * Issue - Add support for skipping error tests.
+* Feature - [Breaking Change] Add `config` to `Hearth::Context` and refactor `logger` and `interceptors` inside of it.
 
 0.3.0 (2024-05-01)
 ------------------

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
@@ -208,19 +208,18 @@ public class ClientGenerator extends RubyGeneratorBase {
                 .write("response: $L,",
                         context.applicationTransport().getResponse()
                                 .render(context))
-                .write("logger: config.logger,")
+                .write("config: config,")
                 .write("operation_name: :$L,", operationName)
-                .write("interceptors: config.interceptors")
                 .closeBlock(")")
-                .write("context.logger.info(\"[#{context.invocation_id}] [#{self.class}#$L] params: #{params}, "
+                .write("context.config.logger.info(\"[#{context.invocation_id}] [#{self.class}#$L] params: #{params}, "
                         + "options: #{options}\")", operationName)
                 .write("output = stack.run(input, context)")
                 .openBlock("if output.error")
-                .write("context.logger.error(\"[#{context.invocation_id}] [#{self.class}#$L] #{output.error} "
+                .write("context.config.logger.error(\"[#{context.invocation_id}] [#{self.class}#$L] #{output.error} "
                         + "(#{output.error.class})\")", operationName)
                 .write("raise output.error")
                 .closeBlock("end")
-                .write("context.logger.info(\"[#{context.invocation_id}] [#{self.class}#$L] #{output.data}\")",
+                .write("context.config.logger.info(\"[#{context.invocation_id}] [#{self.class}#$L] #{output.data}\")",
                         operationName)
                 .write("output")
                 .closeBlock("end");

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
@@ -234,8 +234,9 @@ public class MiddlewareBuilder {
                 .name("interceptors")
                 .defaultValue(Hearth.INTERCEPTOR_LIST + ".new")
                 .documentation(interceptorDocumentation)
-                .rbsType(Hearth.INTERCEPTOR_LIST.toString())
-                .documentationRbsAndValidationType(Hearth.INTERCEPTOR_LIST.toString())
+                .rbsType(Hearth.INTERCEPTOR_LIST + "[Config]")
+                .validateType(Hearth.INTERCEPTOR_LIST.toString())
+                .documentationType(Hearth.INTERCEPTOR_LIST.toString())
                 .documentationDefaultValue(Hearth.INTERCEPTOR_LIST + ".new")
                 .build();
 

--- a/hearth/CHANGELOG.md
+++ b/hearth/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased Changes
 
 * Issue - Fix query param `to_s` for empty arrays.
 * Feature - [Breaking Change] Add `config` to `Hearth::Context` and refactor `logger` and `interceptors` inside of it.
-* Feature - [Breaking Change] Add `config` to `InterceptorContext`.
+* Feature - [Breaking Change] Add `config` to `InterceptorContext` which contains the request config.
 
 1.0.0.pre3 (2024-05-01)
 ------------------

--- a/hearth/CHANGELOG.md
+++ b/hearth/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased Changes
 
 * Issue - Fix query param `to_s` for empty arrays.
 * Feature - [Breaking Change] Add `config` to `Hearth::Context` and refactor `logger` and `interceptors` inside of it.
+* Feature - [Breaking Change] Add `config` to `InterceptorContext`.
 
 1.0.0.pre3 (2024-05-01)
 ------------------

--- a/hearth/CHANGELOG.md
+++ b/hearth/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased Changes
 ------------------
 
 * Issue - Fix query param `to_s` for empty arrays.
+* Feature - [Breaking Change] Add `config` to `Hearth::Context` and refactor `logger` and `interceptors` inside of it.
 
 1.0.0.pre3 (2024-05-01)
 ------------------

--- a/hearth/lib/hearth/client.rb
+++ b/hearth/lib/hearth/client.rb
@@ -38,8 +38,6 @@ module Hearth
     end
 
     def operation_config(options)
-      return @config if options.empty?
-
       if options.include?(:stub_responses) || options.include?(:stubs)
         msg = 'Overriding stubs or stub_responses on ' \
               'operations is not allowed'
@@ -53,7 +51,7 @@ module Hearth
       operation_plugins&.each { |p| p.call(config) }
       config.interceptors.concat(operation_interceptors)
       config.validate!
-      config.freeze
+      config
     end
 
     def output_stream(options = {}, &block)

--- a/hearth/lib/hearth/context.rb
+++ b/hearth/lib/hearth/context.rb
@@ -12,8 +12,7 @@ module Hearth
       @operation_name = options[:operation_name]
       @request = options[:request]
       @response = options[:response]
-      @logger = options[:logger]
-      @interceptors = options[:interceptors] || InterceptorList.new
+      @config = options[:config]
       @auth = options[:auth]
       @metadata = options[:metadata] || {}
     end
@@ -24,17 +23,14 @@ module Hearth
     # @return [Symbol] The name of the API operation called.
     attr_reader :operation_name
 
-    # @return [Hearth::HTTP::Request]
+    # @return [HTTP::Request]
     attr_reader :request
 
-    # @return [Hearth::HTTP::Response]
+    # @return [HTTP::Response]
     attr_reader :response
 
-    # @return [Logger] An instance of the logger configured for the Client.
-    attr_reader :logger
-
-    # @return [Array] An ordered list of interceptors
-    attr_reader :interceptors
+    # @return [Configuration] An instance of operation configuration.
+    attr_reader :config
 
     # @return [ResolvedAuth, nil] The resolved auth for the request.
     attr_accessor :auth

--- a/hearth/lib/hearth/interceptor.rb
+++ b/hearth/lib/hearth/interceptor.rb
@@ -75,7 +75,14 @@ module Hearth
   # * :read_after_execution
   #
   # # Hook Details
-  # The following sections describe each hook in detail.
+  # The following sections describe each hook in detail. For each hook,
+  # {InterceptorContext#config} is ALWAYS available, and will contain a struct
+  # that is an instance of {Configuration}. The config will be the request
+  # options merged with the {Client} configuration.
+  #
+  # Note: {InterceptorContext#config} is not frozen and can be mutated. However,
+  # it is not recommended to mutate either the Interceptors or Plugins during
+  # an Interceptor.
   #
   # ## :read_before_execution
   # A hook called at the start of an execution, before the SDK

--- a/hearth/lib/hearth/interceptor_context.rb
+++ b/hearth/lib/hearth/interceptor_context.rb
@@ -31,8 +31,8 @@ module Hearth
     # @return [Output] Operation output
     attr_reader :output
 
-    # @return [Configuration] logger
-    attr_reader :logger
+    # @return [Configuration] config
+    attr_reader :config
 
     # @return [Hash] attributes Additional interceptor data
     attr_reader :attributes

--- a/hearth/lib/hearth/interceptor_context.rb
+++ b/hearth/lib/hearth/interceptor_context.rb
@@ -5,33 +5,33 @@ module Hearth
   # context to read and modify the input, request, response, and output.
   # Attributes can be used to pass additional data between interceptors.
   class InterceptorContext
-    # @param [Hearth::Structure] input
-    # @param [Hearth::Request] request
-    # @param [Hearth::Response] response
-    # @param [Hearth::Output] output
-    # @param [Logger] logger
-    def initialize(input:, request:, response:, output:, logger:)
+    # @param [Structure] input
+    # @param [Request] request
+    # @param [Response] response
+    # @param [Output] output
+    # @param [Configuration] config
+    def initialize(input:, request:, response:, output:, config:)
       @input = input
       @request = request
       @response = response
       @output = output
-      @logger = logger
+      @config = config
       @attributes = {}
     end
 
     # @return [Struct] Modeled input, i.e. Types::<Operation>Input
     attr_reader :input
 
-    # @return [Hearth::Request]
+    # @return [Request]
     attr_reader :request
 
-    # @return [Hearth::Response]
+    # @return [Response]
     attr_reader :response
 
-    # @return [Hearth::Output] Operation output
+    # @return [Output] Operation output
     attr_reader :output
 
-    # @return [Logger] logger
+    # @return [Configuration] logger
     attr_reader :logger
 
     # @return [Hash] attributes Additional interceptor data

--- a/hearth/lib/hearth/interceptors.rb
+++ b/hearth/lib/hearth/interceptors.rb
@@ -7,8 +7,8 @@ module Hearth
     #
     # @param [Symbol] hook The specific hook to invoke.
     # @param input [Hearth::Structure] input
-    # @param [Hearth::Context] context
-    # @param [Hearth::Output] output
+    # @param [Context] context
+    # @param [Output] output
     # @param [Boolean] aggregate_errors (false) When true, all interceptors are
     #   run and only the last error is returned. When false, returns immediately
     #   if an error is encountered.
@@ -17,7 +17,7 @@ module Hearth
       i_ctx = interceptor_context(input, context, output)
       last_error = nil
 
-      context.interceptors.each do |i|
+      context.config.interceptors.each do |i|
         next unless i.respond_to?(hook)
 
         log_debug(context, i, "Invoking #{hook}")
@@ -43,7 +43,7 @@ module Hearth
           request: context.request,
           response: context.response,
           output: output,
-          logger: context.logger
+          config: context.config
         )
       end
 
@@ -51,7 +51,7 @@ module Hearth
         return unless last_error
 
         message = "Dropping last error: #{last_error} (#{last_error.class})"
-        context.logger.error(
+        context.config.logger.error(
           "[#{context.invocation_id}] [#{interceptor.class}] #{message}"
         )
       end
@@ -61,13 +61,13 @@ module Hearth
         return unless output.error
 
         message = "Dropping last error: #{output.error} (#{output.error.class})"
-        context.logger.error(
+        context.config.logger.error(
           "[#{context.invocation_id}] [Interceptors] #{message}"
         )
       end
 
       def log_debug(context, interceptor, message)
-        context.logger.debug(
+        context.config.logger.debug(
           "[#{context.invocation_id}] [#{interceptor.class}] #{message}"
         )
       end

--- a/hearth/lib/hearth/middleware.rb
+++ b/hearth/lib/hearth/middleware.rb
@@ -8,7 +8,7 @@ module Hearth
       # Logs a debug message to the logger on context. The message is prefixed
       # with the invocation id and the class name.
       def log_debug(context, message)
-        context.logger.debug(
+        context.config.logger.debug(
           "[#{context.invocation_id}] [#{self.class}] #{message}"
         )
       end

--- a/hearth/lib/hearth/middleware/send.rb
+++ b/hearth/lib/hearth/middleware/send.rb
@@ -85,7 +85,7 @@ module Hearth
         @client.transmit(
           request: context.request,
           response: context.response,
-          logger: context.logger
+          logger: context.config.logger
         )
         log_debug(context, "Received response: #{context.response.inspect}")
       rescue Hearth::NetworkingError => e

--- a/hearth/sig/lib/hearth/interceptor_context.rbs
+++ b/hearth/sig/lib/hearth/interceptor_context.rbs
@@ -1,6 +1,6 @@
 module Hearth
   class InterceptorContext
-    def initialize: (input: Structure, request: Request, response: Response, output: Output[Structure], logger: Logger) -> void
+    def initialize: (input: Structure, request: Request, response: Response, output: Output[Structure], config: Configuration[instance]) -> void
 
     attr_reader input: Structure
 
@@ -10,7 +10,7 @@ module Hearth
 
     attr_reader output: Output[Structure]
 
-    attr_reader logger: Logger
+    attr_reader config: Configuration[instance]
 
     attr_reader attributes: Hash[Symbol, untyped]
   end

--- a/hearth/sig/lib/hearth/interceptor_context.rbs
+++ b/hearth/sig/lib/hearth/interceptor_context.rbs
@@ -1,6 +1,6 @@
 module Hearth
-  class InterceptorContext
-    def initialize: (input: Structure, request: Request, response: Response, output: Output[Structure], config: Configuration[instance]) -> void
+  class InterceptorContext[ServiceConfig]
+    def initialize: (input: Structure, request: Request, response: Response, output: Output[Structure], config: Configuration[ServiceConfig]) -> void
 
     attr_reader input: Structure
 
@@ -10,7 +10,7 @@ module Hearth
 
     attr_reader output: Output[Structure]
 
-    attr_reader config: Configuration[instance]
+    attr_reader config: Configuration[ServiceConfig]
 
     attr_reader attributes: Hash[Symbol, untyped]
   end

--- a/hearth/sig/lib/hearth/interceptor_list.rbs
+++ b/hearth/sig/lib/hearth/interceptor_list.rbs
@@ -1,16 +1,16 @@
 module Hearth
-  class InterceptorList
-    include Enumerable[_Interceptor]
+  class InterceptorList[ServiceConfig]
+    include Enumerable[_Interceptor[ServiceConfig]]
 
-    def initialize: (?Array[_Interceptor] interceptors) -> void
+    def initialize: (?Array[_Interceptor[ServiceConfig]] interceptors) -> void
 
-    def append: (_Interceptor interceptor) -> void
+    def append: (_Interceptor[ServiceConfig] interceptor) -> void
     alias << append
 
-    def concat: (InterceptorList other) -> self
+    def concat: (InterceptorList[ServiceConfig] other) -> self
 
-    def dup: () -> InterceptorList
+    def dup: () -> InterceptorList[ServiceConfig]
 
-    def each: () { (_Interceptor) -> untyped } -> untyped
+    def each: () { (_Interceptor[ServiceConfig]) -> untyped } -> untyped
   end
 end

--- a/hearth/sig/lib/hearth/interfaces.rbs
+++ b/hearth/sig/lib/hearth/interfaces.rbs
@@ -15,44 +15,44 @@ module Hearth
     def call: (ServiceConfig) -> void
   end
 
-  interface _Interceptor
-    def read_before_execution: (InterceptorContext) -> void
+  interface _Interceptor[ServiceConfig]
+    def read_before_execution: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_serialization: (InterceptorContext) -> void
+    def modify_before_serialization: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_before_serialization: (InterceptorContext) -> void
+    def read_before_serialization: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_after_serialization: (InterceptorContext) -> void
+    def read_after_serialization: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_retry_loop: (InterceptorContext) -> void
+    def modify_before_retry_loop: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_before_attempt: (InterceptorContext) -> void
+    def read_before_attempt: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_signing: (InterceptorContext) -> void
+    def modify_before_signing: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_before_signing: (InterceptorContext) -> void
+    def read_before_signing: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_after_signing: (InterceptorContext) -> void
+    def read_after_signing: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_transmit: (InterceptorContext) -> void
+    def modify_before_transmit: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_before_transmit: (InterceptorContext) -> void
+    def read_before_transmit: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_after_transmit: (InterceptorContext) -> void
+    def read_after_transmit: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_deserialization: (InterceptorContext) -> void
+    def modify_before_deserialization: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_before_deserialization: (InterceptorContext) -> void
+    def read_before_deserialization: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_after_deserialization: (InterceptorContext) -> void
+    def read_after_deserialization: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_attempt_completion: (InterceptorContext) -> void
+    def modify_before_attempt_completion: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_after_attempt: (InterceptorContext) -> void
+    def read_after_attempt: (InterceptorContext[ServiceConfig]) -> void
 
-    def modify_before_completion: (InterceptorContext) -> void
+    def modify_before_completion: (InterceptorContext[ServiceConfig]) -> void
 
-    def read_after_execution: (InterceptorContext) -> void
+    def read_after_execution: (InterceptorContext[ServiceConfig]) -> void
   end
 
   interface _ErrorInspector

--- a/hearth/spec/client_spec.rb
+++ b/hearth/spec/client_spec.rb
@@ -101,10 +101,6 @@ module Hearth
     end
 
     describe '#operation_config' do
-      it 'returns the client config when no options are set' do
-        expect(subject.operation).to be(subject.config)
-      end
-
       it 'raises errors if stub_responses is set' do
         expect do
           subject.operation({}, stub_responses: true)
@@ -115,6 +111,14 @@ module Hearth
         expect do
           subject.operation({}, stubs: {})
         end.to raise_error(ArgumentError, /not allowed/)
+      end
+
+      it 'returns a config object' do
+        expect(subject.operation).to be_a(Test::Config)
+      end
+
+      it 'has the same values as the client config' do
+        expect(subject.operation).to eq(subject.config)
       end
 
       it 'calls operation plugins' do

--- a/hearth/spec/hearth/context_spec.rb
+++ b/hearth/spec/hearth/context_spec.rb
@@ -6,12 +6,7 @@ module Hearth
     let(:operation_name) { :operation }
     let(:request) { double('request') }
     let(:response) { double('response') }
-    let(:logger) { Logger.new($stdout) }
-    let(:interceptors) do
-      InterceptorList.new [
-        double('interceptor', read_before_execution: nil)
-      ]
-    end
+    let(:config) { double('config') }
     let(:metadata) { { foo: 'bar' } }
 
     subject do
@@ -19,8 +14,7 @@ module Hearth
         operation_name: operation_name,
         request: request,
         response: response,
-        logger: logger,
-        interceptors: interceptors,
+        config: config,
         metadata: metadata
       )
     end
@@ -36,9 +30,7 @@ module Hearth
         expect(context.operation_name).to be_nil
         expect(context.request).to be_nil
         expect(context.response).to be_nil
-        expect(context.logger).to be_nil
-        expect(context.interceptors).to be_a(InterceptorList)
-        expect(context.interceptors.count).to eq(0)
+        expect(context.config).to be_nil
         expect(context.auth).to be_nil
         expect(context.metadata).to eq({})
       end
@@ -48,8 +40,7 @@ module Hearth
         expect(subject.operation_name).to eq(operation_name)
         expect(subject.request).to eq(request)
         expect(subject.response).to eq(response)
-        expect(subject.logger).to eq(logger)
-        expect(subject.interceptors).to eq(interceptors)
+        expect(subject.config).to eq(config)
         expect(subject.auth).to be_nil
         expect(subject.metadata).to eq(metadata)
       end

--- a/hearth/spec/hearth/http/middleware/content_length_spec.rb
+++ b/hearth/spec/hearth/http/middleware/content_length_spec.rb
@@ -19,12 +19,9 @@ module Hearth
           end
           let(:response) { double('response') }
           let(:logger) { Logger.new(IO::NULL) }
+          let(:config) { double('config', logger: logger) }
           let(:context) do
-            Context.new(
-              request: request,
-              response: response,
-              logger: logger
-            )
+            Context.new(request: request, response: response, config: config)
           end
 
           context 'body is not set' do

--- a/hearth/spec/hearth/http/middleware/content_md5_spec.rb
+++ b/hearth/spec/hearth/http/middleware/content_md5_spec.rb
@@ -20,12 +20,9 @@ module Hearth
           end
           let(:response) { double('response') }
           let(:logger) { Logger.new(IO::NULL) }
+          let(:config) { double('config', logger: logger) }
           let(:context) do
-            Context.new(
-              request: request,
-              response: response,
-              logger: logger
-            )
+            Context.new(request: request, response: response, config: config)
           end
 
           context 'Content-MD5 is not set' do

--- a/hearth/spec/hearth/http/middleware/request_compression_spec.rb
+++ b/hearth/spec/hearth/http/middleware/request_compression_spec.rb
@@ -38,11 +38,12 @@ module Hearth
           end
           let(:response) { double('response') }
           let(:logger) { Logger.new(IO::NULL) }
+          let(:config) { double('config', logger: logger) }
           let(:context) do
             Context.new(
               request: request,
               response: response,
-              logger: logger
+              config: config
             )
           end
 

--- a/hearth/spec/hearth/interceptors_spec.rb
+++ b/hearth/spec/hearth/interceptors_spec.rb
@@ -9,22 +9,19 @@ module Hearth
         end
       end
 
+      let(:request) { double('request') }
+      let(:response) { double('response') }
+      let(:logger) { Logger.new(IO::NULL) }
       let(:interceptor1) { interceptor_class.new }
       let(:interceptor2) { interceptor_class.new }
       let(:interceptors) do
         InterceptorList.new([interceptor1, interceptor2])
       end
-
-      let(:request) { double('request') }
-      let(:response) { double('response') }
-      let(:logger) { Logger.new(IO::NULL) }
+      let(:config) do
+        double('config', logger: logger, interceptors: interceptors)
+      end
       let(:context) do
-        Context.new(
-          request: request,
-          response: response,
-          interceptors: interceptors,
-          logger: logger
-        )
+        Context.new(request: request, response: response, config: config)
       end
 
       let(:input) { double('input') }
@@ -40,7 +37,7 @@ module Hearth
           request: request,
           response: response,
           output: output,
-          logger: logger
+          config: config
         ).and_return(i_ctx)
 
         expect(interceptor1).to receive(hook).with(i_ctx)

--- a/hearth/spec/hearth/middleware/auth_spec.rb
+++ b/hearth/spec/hearth/middleware/auth_spec.rb
@@ -88,12 +88,9 @@ module Hearth
         let(:request) { double('request') }
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
+        let(:config) { double('config', logger: logger) }
         let(:context) do
-          Context.new(
-            request: request,
-            response: response,
-            logger: logger
-          )
+          Context.new(request: request, response: response, config: config)
         end
 
         let(:identity_providers) do

--- a/hearth/spec/hearth/middleware/build_spec.rb
+++ b/hearth/spec/hearth/middleware/build_spec.rb
@@ -20,13 +20,11 @@ module Hearth
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
         let(:interceptors) { double('interceptors', each: []) }
+        let(:config) do
+          double('config', logger: logger, interceptors: interceptors)
+        end
         let(:context) do
-          Context.new(
-            request: request,
-            response: response,
-            logger: logger,
-            interceptors: interceptors
-          )
+          Context.new(request: request, response: response, config: config)
         end
 
         it 'builds then calls the next middleware' do

--- a/hearth/spec/hearth/middleware/endpoint_spec.rb
+++ b/hearth/spec/hearth/middleware/endpoint_spec.rb
@@ -27,12 +27,13 @@ module Hearth
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
         let(:resolved_auth) { nil }
+        let(:config) { double('config', logger: logger) }
         let(:context) do
           Context.new(
             request: request,
             response: response,
-            auth: resolved_auth,
-            logger: logger
+            config: config,
+            auth: resolved_auth
           )
         end
         let(:endpoint_auth_schemes) do

--- a/hearth/spec/hearth/middleware/host_prefix_spec.rb
+++ b/hearth/spec/hearth/middleware/host_prefix_spec.rb
@@ -22,12 +22,9 @@ module Hearth
         let(:request) { Hearth::HTTP::Request.new(uri: uri) }
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
+        let(:config) { double('config', logger: logger) }
         let(:context) do
-          Context.new(
-            request: request,
-            response: response,
-            logger: logger
-          )
+          Context.new(request: request, response: response, config: config)
         end
 
         context 'disable_host_prefix is false' do

--- a/hearth/spec/hearth/middleware/initialize_spec.rb
+++ b/hearth/spec/hearth/middleware/initialize_spec.rb
@@ -14,13 +14,11 @@ module Hearth
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
         let(:interceptors) { double('interceptors', each: []) }
+        let(:config) do
+          double('config', logger: logger, interceptors: interceptors)
+        end
         let(:context) do
-          Context.new(
-            request: request,
-            response: response,
-            logger: logger,
-            interceptors: interceptors
-          )
+          Context.new(request: request, response: response, config: config)
         end
 
         context 'no errors' do

--- a/hearth/spec/hearth/middleware/parse_spec.rb
+++ b/hearth/spec/hearth/middleware/parse_spec.rb
@@ -18,13 +18,11 @@ module Hearth
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
         let(:interceptors) { double('interceptors', each: []) }
+        let(:config) do
+          double('config', logger: logger, interceptors: interceptors)
+        end
         let(:context) do
-          Context.new(
-            request: request,
-            response: response,
-            logger: logger,
-            interceptors: interceptors
-          )
+          Context.new(request: request, response: response, config: config)
         end
 
         let(:metadata) { { key: 'value' } }

--- a/hearth/spec/hearth/middleware/retry_spec.rb
+++ b/hearth/spec/hearth/middleware/retry_spec.rb
@@ -104,15 +104,13 @@ module Hearth
 
       let(:request) { Hearth::HTTP::Request.new }
       let(:response) { Hearth::HTTP::Response.new }
-      let(:interceptors) { double('interceptors', each: []) }
       let(:logger) { Logger.new(IO::NULL) }
+      let(:interceptors) { double('interceptors', each: []) }
+      let(:config) do
+        double('config', logger: logger, interceptors: interceptors)
+      end
       let(:context) do
-        Hearth::Context.new(
-          request: request,
-          response: response,
-          logger: logger,
-          interceptors: interceptors
-        )
+        Context.new(request: request, response: response, config: config)
       end
 
       before { allow(error).to receive(:retryable?).and_return(true) }

--- a/hearth/spec/hearth/middleware/send_spec.rb
+++ b/hearth/spec/hearth/middleware/send_spec.rb
@@ -59,13 +59,15 @@ module Hearth
         let(:operation) { :operation }
         let(:logger) { Logger.new(IO::NULL) }
         let(:interceptors) { double('interceptors', each: []) }
+        let(:config) do
+          double('config', logger: logger, interceptors: interceptors)
+        end
         let(:context) do
           Hearth::Context.new(
+            operation_name: operation,
             request: request,
             response: response,
-            operation_name: operation,
-            logger: logger,
-            interceptors: interceptors
+            config: config
           )
         end
 

--- a/hearth/spec/hearth/middleware/sign_spec.rb
+++ b/hearth/spec/hearth/middleware/sign_spec.rb
@@ -14,13 +14,11 @@ module Hearth
         let(:response) { double('response') }
         let(:logger) { Logger.new(IO::NULL) }
         let(:interceptors) { double('interceptors', each: []) }
+        let(:config) do
+          double('config', logger: logger, interceptors: interceptors)
+        end
         let(:context) do
-          Context.new(
-            request: request,
-            response: response,
-            logger: logger,
-            interceptors: interceptors
-          )
+          Context.new(request: request, response: response, config: config)
         end
 
         let(:signer) { double('signer', sign: nil) }

--- a/hearth/spec/hearth/middleware/validate_spec.rb
+++ b/hearth/spec/hearth/middleware/validate_spec.rb
@@ -17,9 +17,8 @@ module Hearth
 
       describe '#call' do
         let(:logger) { Logger.new(IO::NULL) }
-        let(:context) do
-          Hearth::Context.new(logger: logger)
-        end
+        let(:config) { double('config', logger: logger) }
+        let(:context) { Context.new(config: config) }
 
         context 'validate_input is true' do
           let(:validate_input) { true }


### PR DESCRIPTION
This change adds operation `config` (unfrozen) to Hearth::Context and also InterceptorContext, so that interceptors may modify operation config.