### PR TITLE
Add support for stringArray parameters + operationContextParams

### DIFF
--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -1057,9 +1057,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.empty_input_and_empty_output({
-
-          }, **opts)
+          client.empty_input_and_empty_output({}, **opts)
         end
 
       end
@@ -1078,9 +1076,7 @@ module RailsJson
           client.stub_responses(:empty_input_and_empty_output, response)
           allow(Builders::EmptyInputAndEmptyOutput).to receive(:build)
           output = client.empty_input_and_empty_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # This test ensures that clients can gracefully handle
@@ -1093,9 +1089,7 @@ module RailsJson
           client.stub_responses(:empty_input_and_empty_output, response)
           allow(Builders::EmptyInputAndEmptyOutput).to receive(:build)
           output = client.empty_input_and_empty_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -1111,13 +1105,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::EmptyInputAndEmptyOutput).to receive(:build)
-          client.stub_responses(:empty_input_and_empty_output, data: {
-
-          })
+          client.stub_responses(:empty_input_and_empty_output, data: {})
           output = client.empty_input_and_empty_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # This test ensures that clients can gracefully handle
@@ -1128,13 +1118,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::EmptyInputAndEmptyOutput).to receive(:build)
-          client.stub_responses(:empty_input_and_empty_output, data: {
-
-          })
+          client.stub_responses(:empty_input_and_empty_output, data: {})
           output = client.empty_input_and_empty_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -1158,9 +1144,7 @@ module RailsJson
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
           opts[:endpoint] = 'http://example.com'
-          client.endpoint_operation({
-
-          }, **opts)
+          client.endpoint_operation({}, **opts)
         end
 
       end
@@ -1431,25 +1415,19 @@ module RailsJson
           begin
             output = client.greeting_with_errors({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
           rescue Errors::ComplexError => e
-            expect(e.data.to_h).to eq({
-
-            })
+            expect(e.data.to_h).to eq({})
           end
         end
 
         #
         it 'stubs RailsJsonEmptyComplexErrorWithNoMessage' do
-          client.stub_responses(:greeting_with_errors, error: { class: Errors::ComplexError, data: {
-
-          } })
+          client.stub_responses(:greeting_with_errors, error: { class: Errors::ComplexError, data: {} })
           allow(Builders::GreetingWithErrors).to receive(:build)
           begin
             output = client.greeting_with_errors({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
           rescue Errors::ComplexError => e
             expect(e.http_status).to eq(403)
-            expect(e.data.to_h).to eq({
-
-            })
+            expect(e.data.to_h).to eq({})
           end
         end
       end
@@ -1471,9 +1449,7 @@ module RailsJson
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
           opts[:endpoint] = 'http://example.com/custom'
-          client.host_with_path_operation({
-
-          }, **opts)
+          client.host_with_path_operation({}, **opts)
         end
 
       end
@@ -1869,9 +1845,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.http_payload_with_union({
-
-          }, **opts)
+          client.http_payload_with_union({}, **opts)
         end
 
       end
@@ -1907,9 +1881,7 @@ module RailsJson
           client.stub_responses(:http_payload_with_union, response)
           allow(Builders::HttpPayloadWithUnion).to receive(:build)
           output = client.http_payload_with_union({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -1943,13 +1915,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::HttpPayloadWithUnion).to receive(:build)
-          client.stub_responses(:http_payload_with_union, data: {
-
-          })
+          client.stub_responses(:http_payload_with_union, data: {})
           output = client.http_payload_with_union({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -2452,9 +2420,7 @@ module RailsJson
           client.stub_responses(:ignore_query_params_in_response, response)
           allow(Builders::IgnoreQueryParamsInResponse).to receive(:build)
           output = client.ignore_query_params_in_response({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # This test is similar to RailsJsonIgnoreQueryParamsInResponse,
@@ -2468,9 +2434,7 @@ module RailsJson
           client.stub_responses(:ignore_query_params_in_response, response)
           allow(Builders::IgnoreQueryParamsInResponse).to receive(:build)
           output = client.ignore_query_params_in_response({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -2487,13 +2451,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::IgnoreQueryParamsInResponse).to receive(:build)
-          client.stub_responses(:ignore_query_params_in_response, data: {
-
-          })
+          client.stub_responses(:ignore_query_params_in_response, data: {})
           output = client.ignore_query_params_in_response({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # This test is similar to RailsJsonIgnoreQueryParamsInResponse,
@@ -2505,13 +2465,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::IgnoreQueryParamsInResponse).to receive(:build)
-          client.stub_responses(:ignore_query_params_in_response, data: {
-
-          })
+          client.stub_responses(:ignore_query_params_in_response, data: {})
           output = client.ignore_query_params_in_response({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -5409,9 +5365,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.no_input_and_no_output({
-
-          }, **opts)
+          client.no_input_and_no_output({}, **opts)
         end
 
       end
@@ -5429,9 +5383,7 @@ module RailsJson
           client.stub_responses(:no_input_and_no_output, response)
           allow(Builders::NoInputAndNoOutput).to receive(:build)
           output = client.no_input_and_no_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -5447,13 +5399,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::NoInputAndNoOutput).to receive(:build)
-          client.stub_responses(:no_input_and_no_output, data: {
-
-          })
+          client.stub_responses(:no_input_and_no_output, data: {})
           output = client.no_input_and_no_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -5476,9 +5424,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.no_input_and_output({
-
-          }, **opts)
+          client.no_input_and_output({}, **opts)
         end
 
       end
@@ -5496,9 +5442,7 @@ module RailsJson
           client.stub_responses(:no_input_and_output, response)
           allow(Builders::NoInputAndOutput).to receive(:build)
           output = client.no_input_and_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # This test is similar to RailsJsonNoInputAndOutputWithJson, but
@@ -5512,9 +5456,7 @@ module RailsJson
           client.stub_responses(:no_input_and_output, response)
           allow(Builders::NoInputAndOutput).to receive(:build)
           output = client.no_input_and_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -5529,13 +5471,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::NoInputAndOutput).to receive(:build)
-          client.stub_responses(:no_input_and_output, data: {
-
-          })
+          client.stub_responses(:no_input_and_output, data: {})
           output = client.no_input_and_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # This test is similar to RailsJsonNoInputAndOutputWithJson, but
@@ -5547,13 +5485,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::NoInputAndOutput).to receive(:build)
-          client.stub_responses(:no_input_and_output, data: {
-
-          })
+          client.stub_responses(:no_input_and_output, data: {})
           output = client.no_input_and_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -5732,9 +5666,7 @@ module RailsJson
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
           client.operation_with_defaults({
-            defaults: {
-
-            }
+            defaults: {}
           }, **opts)
         end
 
@@ -5750,9 +5682,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.operation_with_defaults({
-
-          }, **opts)
+          client.operation_with_defaults({}, **opts)
         end
 
         # Client uses explicitly provided member values over defaults
@@ -5869,9 +5799,7 @@ module RailsJson
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
           client.operation_with_defaults({
-            client_optional_defaults: {
-
-            }
+            client_optional_defaults: {}
           }, **opts)
         end
 
@@ -6225,13 +6153,9 @@ module RailsJson
                 language: "en"
               },
               dialog_list: [
+                {},
                 {
-
-                },
-                {
-                  farewell: {
-
-                  }
+                  farewell: {}
                 },
                 {
                   language: "it",
@@ -6242,14 +6166,10 @@ module RailsJson
                 }
               ],
               dialog_map: {
-                'emptyDialog' => {
-
-                },
+                'emptyDialog' => {},
                 'partialEmptyDialog' => {
                   language: "en",
-                  farewell: {
-
-                  }
+                  farewell: {}
                 },
                 'nonEmptyDialog' => {
                   greeting: "konnichiwa",
@@ -6475,9 +6395,7 @@ module RailsJson
           opts = {interceptors: [interceptor]}
           client.post_player_action({
             action: {
-              quit: {
-
-              }
+              quit: {}
             }
           }, **opts)
         end
@@ -6502,9 +6420,7 @@ module RailsJson
           output = client.post_player_action({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
           expect(output.data.to_h).to eq({
             action: {
-              quit: {
-
-              }
+              quit: {}
             }
           })
         end
@@ -6522,17 +6438,13 @@ module RailsJson
           allow(Builders::PostPlayerAction).to receive(:build)
           client.stub_responses(:post_player_action, data: {
             action: {
-              quit: {
-
-              }
+              quit: {}
             }
           })
           output = client.post_player_action({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
           expect(output.data.to_h).to eq({
             action: {
-              quit: {
-
-              }
+              quit: {}
             }
           })
         end
@@ -6808,9 +6720,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.query_idempotency_token_auto_fill({
-
-          }, **opts)
+          client.query_idempotency_token_auto_fill({}, **opts)
         end
 
         # Uses the given idempotency token as-is
@@ -7203,9 +7113,7 @@ module RailsJson
           client.stub_responses(:simple_scalar_properties, response)
           allow(Builders::SimpleScalarProperties).to receive(:build)
           output = client.simple_scalar_properties({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # Supports handling NaN float values.
@@ -7310,13 +7218,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::SimpleScalarProperties).to receive(:build)
-          client.stub_responses(:simple_scalar_properties, data: {
-
-          })
+          client.stub_responses(:simple_scalar_properties, data: {})
           output = client.simple_scalar_properties({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
         # Supports handling NaN float values.
@@ -8233,9 +8137,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.test_body_structure({
-
-          }, **opts)
+          client.test_body_structure({}, **opts)
         end
 
       end
@@ -8257,9 +8159,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.test_no_payload({
-
-          }, **opts)
+          client.test_no_payload({}, **opts)
         end
 
         # Serializes a GET request with header member but no modeled body
@@ -8298,9 +8198,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.test_payload_blob({
-
-          }, **opts)
+          client.test_payload_blob({}, **opts)
         end
 
         # Serializes a payload targeting a blob
@@ -8341,9 +8239,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.test_payload_structure({
-
-          }, **opts)
+          client.test_payload_structure({}, **opts)
         end
 
         # Serializes a payload targeting a structure
@@ -8494,9 +8390,7 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.unit_input_and_output({
-
-          }, **opts)
+          client.unit_input_and_output({}, **opts)
         end
 
       end
@@ -8514,9 +8408,7 @@ module RailsJson
           client.stub_responses(:unit_input_and_output, response)
           allow(Builders::UnitInputAndOutput).to receive(:build)
           output = client.unit_input_and_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end
@@ -8532,13 +8424,9 @@ module RailsJson
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::UnitInputAndOutput).to receive(:build)
-          client.stub_responses(:unit_input_and_output, data: {
-
-          })
+          client.stub_responses(:unit_input_and_output, data: {})
           output = client.unit_input_and_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to eq({
-
-          })
+          expect(output.data.to_h).to eq({})
         end
 
       end

--- a/codegen/projections/rpcv2_cbor/spec/protocol_spec.rb
+++ b/codegen/projections/rpcv2_cbor/spec/protocol_spec.rb
@@ -40,9 +40,7 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.empty_input_output({
-
-          }, **opts)
+          client.empty_input_output({}, **opts)
         end
 
       end
@@ -60,9 +58,7 @@ module Rpcv2Cbor
           client.stub_responses(:empty_input_output, response)
           allow(Builders::EmptyInputOutput).to receive(:build)
           output = client.empty_input_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # When output structure is empty the client should accept an empty body
@@ -76,9 +72,7 @@ module Rpcv2Cbor
           client.stub_responses(:empty_input_output, response)
           allow(Builders::EmptyInputOutput).to receive(:build)
           output = client.empty_input_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
       end
@@ -92,13 +86,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::EmptyInputOutput).to receive(:build)
-          client.stub_responses(:empty_input_output, data: {
-
-          })
+          client.stub_responses(:empty_input_output, data: {})
           output = client.empty_input_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # When output structure is empty the client should accept an empty body
@@ -108,13 +98,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::EmptyInputOutput).to receive(:build)
-          client.stub_responses(:empty_input_output, data: {
-
-          })
+          client.stub_responses(:empty_input_output, data: {})
           output = client.empty_input_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
       end
@@ -436,25 +422,19 @@ module Rpcv2Cbor
           begin
             output = client.greeting_with_errors({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
           rescue Errors::ComplexError => e
-            expect(e.data.to_h).to eq({
-
-            })
+            expect(e.data.to_h).to eq({})
           end
         end
 
         #
         it 'stubs RpcV2CborEmptyComplexError' do
-          client.stub_responses(:greeting_with_errors, error: { class: Errors::ComplexError, data: {
-
-          } })
+          client.stub_responses(:greeting_with_errors, error: { class: Errors::ComplexError, data: {} })
           allow(Builders::GreetingWithErrors).to receive(:build)
           begin
             output = client.greeting_with_errors({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
           rescue Errors::ComplexError => e
             expect(e.http_status).to eq(400)
-            expect(e.data.to_h).to eq({
-
-            })
+            expect(e.data.to_h).to eq({})
           end
         end
       end
@@ -477,9 +457,7 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.no_input_output({
-
-          }, **opts)
+          client.no_input_output({}, **opts)
         end
 
       end
@@ -496,9 +474,7 @@ module Rpcv2Cbor
           client.stub_responses(:no_input_output, response)
           allow(Builders::NoInputOutput).to receive(:build)
           output = client.no_input_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # Clients should accept a CBOR empty struct if there is no output.
@@ -512,9 +488,7 @@ module Rpcv2Cbor
           client.stub_responses(:no_input_output, response)
           allow(Builders::NoInputOutput).to receive(:build)
           output = client.no_input_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # Clients should accept an empty body if there is no output and
@@ -529,9 +503,7 @@ module Rpcv2Cbor
           client.stub_responses(:no_input_output, response)
           allow(Builders::NoInputOutput).to receive(:build)
           output = client.no_input_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
       end
@@ -545,13 +517,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::NoInputOutput).to receive(:build)
-          client.stub_responses(:no_input_output, data: {
-
-          })
+          client.stub_responses(:no_input_output, data: {})
           output = client.no_input_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # Clients should accept a CBOR empty struct if there is no output.
@@ -561,13 +529,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::NoInputOutput).to receive(:build)
-          client.stub_responses(:no_input_output, data: {
-
-          })
+          client.stub_responses(:no_input_output, data: {})
           output = client.no_input_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # Clients should accept an empty body if there is no output and
@@ -578,13 +542,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::NoInputOutput).to receive(:build)
-          client.stub_responses(:no_input_output, data: {
-
-          })
+          client.stub_responses(:no_input_output, data: {})
           output = client.no_input_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
       end
@@ -608,9 +568,7 @@ module Rpcv2Cbor
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
           client.operation_with_defaults({
-            defaults: {
-
-            }
+            defaults: {}
           }, **opts)
         end
 
@@ -626,9 +584,7 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.operation_with_defaults({
-
-          }, **opts)
+          client.operation_with_defaults({}, **opts)
         end
 
         # Client uses explicitly provided member values over defaults
@@ -707,9 +663,7 @@ module Rpcv2Cbor
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
           client.operation_with_defaults({
-            client_optional_defaults: {
-
-            }
+            client_optional_defaults: {}
           }, **opts)
         end
 
@@ -961,9 +915,7 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
           opts = {interceptors: [interceptor]}
-          client.optional_input_output({
-
-          }, **opts)
+          client.optional_input_output({}, **opts)
         end
 
       end
@@ -981,9 +933,7 @@ module Rpcv2Cbor
           client.stub_responses(:optional_input_output, response)
           allow(Builders::OptionalInputOutput).to receive(:build)
           output = client.optional_input_output({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
       end
@@ -997,13 +947,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::OptionalInputOutput).to receive(:build)
-          client.stub_responses(:optional_input_output, data: {
-
-          })
+          client.stub_responses(:optional_input_output, data: {})
           output = client.optional_input_output({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
       end
@@ -2506,9 +2452,7 @@ module Rpcv2Cbor
           client.stub_responses(:simple_scalar_properties, response)
           allow(Builders::SimpleScalarProperties).to receive(:build)
           output = client.simple_scalar_properties({}, auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # Supports handling NaN float values.
@@ -2684,13 +2628,9 @@ module Rpcv2Cbor
           end
           interceptor = Hearth::Interceptor.new(read_after_transmit: proc)
           allow(Builders::SimpleScalarProperties).to receive(:build)
-          client.stub_responses(:simple_scalar_properties, data: {
-
-          })
+          client.stub_responses(:simple_scalar_properties, data: {})
           output = client.simple_scalar_properties({}, interceptors: [interceptor], auth_resolver: Hearth::AnonymousAuthResolver.new)
-          expect(output.data.to_h).to match_cbor({
-
-          })
+          expect(output.data.to_h).to match_cbor({})
         end
 
         # Supports handling NaN float values.

--- a/codegen/projections/white_label/spec/endpoint_spec.rb
+++ b/codegen/projections/white_label/spec/endpoint_spec.rb
@@ -49,7 +49,9 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.endpoint_operation({}, interceptors: [interceptor])
+          client.endpoint_operation({
+
+          }, interceptors: [interceptor])
         end
       end
 
@@ -118,7 +120,9 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.endpoint_operation({}, interceptors: [interceptor])
+          client.endpoint_operation({
+
+          }, interceptors: [interceptor])
         end
       end
 
@@ -156,7 +160,9 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.resource_endpoint({resource_url: 'https://resource.com/path'}, interceptors: [interceptor])
+          client.resource_endpoint({
+            resource_url: "https://resource.com/path"
+          }, interceptors: [interceptor])
         end
       end
 
@@ -194,7 +200,9 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.dataplane_endpoint({}, interceptors: [interceptor])
+          client.dataplane_endpoint({
+
+          }, interceptors: [interceptor])
         end
 
         it 'produces the correct output from the client when calling endpoint_with_host_label_operation' do
@@ -214,7 +222,9 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.endpoint_with_host_label_operation({label_member: 'label'}, interceptors: [interceptor])
+          client.endpoint_with_host_label_operation({
+            label_member: "label"
+          }, interceptors: [interceptor])
         end
       end
     end

--- a/codegen/projections/white_label/spec/endpoint_spec.rb
+++ b/codegen/projections/white_label/spec/endpoint_spec.rb
@@ -49,9 +49,7 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.endpoint_operation({
-
-          }, interceptors: [interceptor])
+          client.endpoint_operation({}, interceptors: [interceptor])
         end
       end
 
@@ -120,9 +118,7 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.endpoint_operation({
-
-          }, interceptors: [interceptor])
+          client.endpoint_operation({}, interceptors: [interceptor])
         end
       end
 
@@ -200,9 +196,7 @@ module WhiteLabel
             end
           end
           interceptor = Hearth::Interceptor.new(read_before_transmit: proc)
-          client.dataplane_endpoint({
-
-          }, interceptors: [interceptor])
+          client.dataplane_endpoint({}, interceptors: [interceptor])
         end
 
         it 'produces the correct output from the client when calling endpoint_with_host_label_operation' do

--- a/codegen/smithy-ruby-codegen-test/model/test-services/endpoints-string-array.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/test-services/endpoints-string-array.smithy
@@ -1,0 +1,188 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+use smithy.rules#staticContextParams
+use smithy.rules#operationContextParams
+
+@endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        stringArrayParam: {
+            type: "stringArray",
+            required: true,
+            default: ["defaultValue1", "defaultValue2"],
+            documentation: "docs"
+        }
+    },
+    rules: [
+        {
+            "documentation": "Template first array value into URI if set",
+            "conditions": [
+                {
+                    "fn": "getAttr",
+                    "argv": [
+                        {
+                            "ref": "stringArrayParam"
+                        },
+                        "[0]"
+                    ],
+                    "assign": "arrayValue"
+                }
+            ],
+            "endpoint": {
+                "url": "https://example.com/{arrayValue}"
+            },
+            "type": "endpoint"
+        },
+        {
+            "conditions": [],
+            "documentation": "error fallthrough",
+            "error": "no array values set",
+            "type": "error"
+        }
+    ]
+})
+@endpointTests({
+    "version": "1.0",
+    "testCases": [
+        {
+            "documentation": "Default array values used"
+            "params": {}
+            "expect": {
+                "endpoint": {
+                    "url": "https://example.com/defaultValue1"
+                }
+            },
+            "operationInputs": [
+                {
+                    "operationName": "NoBindingsOperation",
+                }
+            ]
+        },
+        {
+            "documentation": "Empty array",
+            "params": {
+                "stringArrayParam": []
+            }
+            "expect": {
+                "error": "no array values set"
+            },
+            "operationInputs": [
+                {
+                    "operationName": "EmptyStaticContextOperation",
+                }
+            ]
+        },
+        {
+            "documentation": "Static value",
+            "params": {
+                "stringArrayParam": ["staticValue1"]
+            }
+            "expect": {
+                "endpoint": {
+                    "url": "https://example.com/staticValue1"
+                }
+            },
+            "operationInputs": [
+                {
+                    "operationName": "StaticContextOperation",
+                }
+            ]
+        },
+        {
+            "documentation": "bound value from input",
+            "params": {
+                "stringArrayParam": ["key1"]
+            }
+            "expect": {
+                "endpoint": {
+                    "url": "https://example.com/key1"
+                }
+            },
+            "operationInputs": [
+                {
+                    "operationName": "ListOfObjectsOperation",
+                    "operationParams": {
+                        "nested": {
+                            "listOfObjects": [{"key": "key1"}]
+                        }
+                    },
+                },
+                {
+                    "operationName": "MapOperation",
+                    "operationParams": {
+                        "map": {
+                            "key1": "value1"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+})
+service EndpointStringArrayService {
+    version: "2022-01-01",
+    operations: [
+        NoBindingsOperation,
+        EmptyStaticContextOperation,
+        StaticContextOperation,
+        ListOfObjectsOperation,
+        MapOperation
+    ]
+}
+
+operation NoBindingsOperation {
+    input:= {}
+}
+
+@staticContextParams(
+    "stringArrayParam": {value: []}
+)
+operation EmptyStaticContextOperation {
+    input := {}
+}
+
+@staticContextParams(
+    "stringArrayParam": {value: ["staticValue1"]}
+)
+operation StaticContextOperation {
+    input := {}
+}
+
+@operationContextParams(
+    "stringArrayParam": {path: "nested.listOfObjects[*].key"}
+)
+operation ListOfObjectsOperation {
+    input:= {
+        nested: Nested
+    }
+}
+
+@operationContextParams(
+    "stringArrayParam": {path: "keys(map)"}
+)
+operation MapOperation {
+    input:= {
+        map: Map
+    }
+}
+
+structure Nested {
+    listOfObjects: ListOfObjects
+}
+
+list ListOfObjects {
+    member: ObjectMember
+}
+
+structure ObjectMember {
+    key: String,
+}
+
+map Map {
+    key: String,
+    value: String
+}

--- a/codegen/smithy-ruby-codegen/CHANGELOG.md
+++ b/codegen/smithy-ruby-codegen/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add support for stringArray Endpoint parameters + operationContextParams binding.
 * Feature - Add support for Smithy RPC v2 CBOR protocol.
 * Issue - Use `strict_encode64` instead of `encode64`.
 * Issue - Fix builders when `uri` contains empty query parameter.

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.ruby.codegen.middleware.factories.ContentLengthMid
 import software.amazon.smithy.ruby.codegen.middleware.factories.ContentMD5MiddlewareFactory;
 import software.amazon.smithy.ruby.codegen.middleware.factories.ParseMiddlewareFactory;
 import software.amazon.smithy.ruby.codegen.middleware.factories.RequestCompressionMiddlewareFactory;
+import software.amazon.smithy.ruby.codegen.rulesengine.BuiltInBinding;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 
@@ -101,6 +102,7 @@ public final class ApplicationTransport {
 
         ClientFragment client = ClientFragment.builder()
                 .addConfig(httpClient)
+                .addConfig(BuiltInBinding.SDK_ENDPOINT_CONFIG)
                 .render((self, ctx) -> httpClient.renderGetConfigValue())
                 .build();
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -865,7 +865,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                         context.model().expectShape(
                                                 left.right.asListShape().get().getMember().getTarget())));
                 return Pair.of(
-                        left.left + ".map { |o| o" + right.left + "}",
+                        left.left + ".map { |o| o" + right.left + " }",
                         right.right
                 );
             } else {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -834,7 +834,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                         context.model().expectShape(
                                                 left.right.asMapShape().get().getValue().getTarget())));
                 return Pair.of(
-                        left.left + ".values.map { |o| o" + right.left + "}",
+                        left.left + ".values.map { |o| o" + right.left + "}.compact",
                         right.right
                 );
             } else {
@@ -865,7 +865,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                         context.model().expectShape(
                                                 left.right.asListShape().get().getMember().getTarget())));
                 return Pair.of(
-                        left.left + ".map { |o| o" + right.left + " }",
+                        left.left + ".map { |o| o" + right.left + " }.compact",
                         right.right
                 );
             } else {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -834,7 +834,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                         context.model().expectShape(
                                                 left.right.asMapShape().get().getValue().getTarget())));
                 return Pair.of(
-                        left.left + ".values.map { |o| o" + right.left + "}.compact",
+                        left.left + ".values.map { |o| o" + right.left + " }.compact",
                         right.right
                 );
             } else {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/rulesengine/BuiltInBinding.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/rulesengine/BuiltInBinding.java
@@ -38,6 +38,16 @@ import software.amazon.smithy.utils.StringUtils;
  * Provides a binding between Smithy rules engine built-ins and Ruby code.
  */
 public final class BuiltInBinding {
+    public static final ClientConfig SDK_ENDPOINT_CONFIG = ClientConfig.builder()
+            .name("endpoint")
+            .documentationRbsAndValidationType("String")
+            .documentation("Endpoint of the service")
+            .defaultDynamicValue("cfg[:stub_responses] ? 'http://localhost' : nil")
+            .build();
+    public static final BuiltInBinding ENDPOINT_BUILT_IN_BINDING = BuiltInBinding.builder()
+            .builtIn(BuiltIns.SDK_ENDPOINT)
+            .fromConfig(SDK_ENDPOINT_CONFIG)
+            .build();
     private final Parameter builtIn;
     private final Set<ClientConfig> clientConfig;
     private final RenderBuild renderBuild;
@@ -59,15 +69,7 @@ public final class BuiltInBinding {
     public static Set<BuiltInBinding> defaultBuiltInBindings() {
 
         return Set.of(
-                BuiltInBinding.builder()
-                        .builtIn(BuiltIns.SDK_ENDPOINT)
-                        .fromConfig(ClientConfig.builder()
-                                .name("endpoint")
-                                .documentationRbsAndValidationType("String")
-                                .documentation("Endpoint of the service")
-                                .defaultDynamicValue("cfg[:stub_responses] ? 'http://localhost' : nil")
-                                .build())
-                        .build()
+                ENDPOINT_BUILT_IN_BINDING
         );
     }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
@@ -247,6 +247,9 @@ public class ParamsToHash extends ShapeVisitor.Default<String> {
         }
         ObjectNode objectNode = node.expectObjectNode();
         Map<StringNode, Node> members = objectNode.getMembers();
+        if (members.isEmpty()) {
+            return "{}";
+        }
 
         Map<String, MemberShape> shapeMembers = shape.getAllMembers();
 

--- a/hearth/CHANGELOG.md
+++ b/hearth/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+
 * Feature - Add `Hearth::Cbor.encode` and `Hearth::Cbor.decode`.
 * Issue - Fix query param `to_s` for empty arrays.
 * Feature - [Breaking Change] Add `config` to `Hearth::Context` and refactor `logger` and `interceptors` inside of it.

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -26,7 +26,7 @@ namespace :test do
     build_dir = 'codegen/smithy-ruby-codegen-test/build/smithyprojections/smithy-ruby-codegen-test'
 
     test_sdk_dirs = Dir.glob("#{build_dir}/*/ruby-codegen/*")
-                       .select { |d| !d.include?('white_label') && Dir.exist?("#{d}/spec") }
+                       .select { |d| !d.include?('white_label') && !d.include?('rpcv2cbor') && Dir.exist?("#{d}/spec") }
 
     specs = test_sdk_dirs.map { |d| "#{d}/spec" }.join(' ')
     includes = test_sdk_dirs.map { |d|


### PR DESCRIPTION

*Description of changes:*
Add support for stringArray parameters + operationContextParams.
See: 
* Smithy reference for [Parameters](https://smithy.io/2.0/additional-specs/rules-engine/parameters.html#rules-engine-parameters)
* [operationContextParams docs](https://smithy.io/2.0/additional-specs/rules-engine/parameters.html#smithy-rules-operationcontextparams-trait)
* [V3 PR](https://github.com/aws/aws-sdk-ruby/pull/3050)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
