### PR TITLE
Add support for bignum/bigdecimal to CBOR encoder/decoder

### DIFF
--- a/hearth/spec/hearth/cbor/decoder_spec.rb
+++ b/hearth/spec/hearth/cbor/decoder_spec.rb
@@ -10,6 +10,10 @@ module Hearth
         Decoder.new(Base64.decode64(value)).decode
       end
 
+      def encode_decode(value)
+        Decoder.new(Encoder.new.add(value).bytes).decode
+      end
+
       describe '#decode' do
         it 'raises when there are extra bytes' do
           expect do
@@ -60,6 +64,32 @@ module Hearth
         it 'decodes integer times' do
           expect(cbor64_decode('wRsAAAFvYQ3z8A=='))
             .to eq(Time.parse('2020-01-01 12:21:42Z'))
+        end
+
+        it 'decodes positive BigNums' do
+          value = (2**64) + 1
+          expect(encode_decode(value)).to eq(value)
+        end
+
+        it 'decodes negative BigNums' do
+          value = -1 * ((2**64) + 1)
+          expect(encode_decode(value)).to eq(value)
+        end
+
+        it 'decodes BigDecimals' do
+          value = BigDecimal('273.15')
+          expect(encode_decode(value)).to eq(value)
+        end
+
+        it 'raises on invalid BigDecimals' do
+          # https://www.rfc-editor.org/rfc/rfc8949.html#name-decimal-fractions-and-bigfl
+          # C4 83 21 19 6A B3
+          # array length of 3
+          expect do
+            Decoder.new(['c48321196ab3'].pack('H*')).decode
+          end.to raise_error(
+            Error, 'Expected array of length 2 but length is: 3'
+          )
         end
       end
     end

--- a/hearth/spec/hearth/cbor/encoder_spec.rb
+++ b/hearth/spec/hearth/cbor/encoder_spec.rb
@@ -8,7 +8,7 @@ module Hearth
       let(:time) { Time.parse('2020-01-01 12:21:42Z') }
 
       def cbor64_encode(value)
-        Base64.encode64(Encoder.new.add(value).bytes)
+        Base64.strict_encode64(Encoder.new.add(value).bytes)
               .strip.force_encoding('UTF-8')
       end
 
@@ -77,6 +77,18 @@ module Hearth
 
         it 'encodes times' do
           expect(cbor64_encode(time)).to eq('wRsAAAFvYQ3z8A==')
+        end
+
+        it 'encodes BigDecimals' do
+          # see example at:
+          # https://www.rfc-editor.org/rfc/rfc8949.html#name-decimal-fractions-and-bigfl
+          expect(cbor64_encode(BigDecimal('273.15')))
+            .to eq('xIIhGWqz') # C4 82 21 19 6AB3 in hex
+          # encodes as floating point numbers
+          expect(cbor64_encode(BigDecimal('Infinity')))
+            .to eq('+n+AAAA=')
+          expect(cbor64_encode(BigDecimal('NaN')))
+            .to eq('+n/AAAA=')
         end
 
         it 'raises on unknown items' do


### PR DESCRIPTION
*Description of changes:*
Port [V3 support for BigNumber and BigDecimal](https://github.com/aws/aws-sdk-ruby/pull/3006/commits/3a079f6454cea6ed9b834d0ceb35065d94f86adc) to Hearth.

This relies implicitly on bigdecimal, which will no longer be a default gem in Ruby 3.4.  This change does NOT add bigdecimal to the gemspec as a dependency.  We still need to evaluate how we want to handle this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
