### PR TITLE
Update reserved member names for new Struct methods

### DIFF
--- a/codegen/smithy-ruby-codegen/CHANGELOG.md
+++ b/codegen/smithy-ruby-codegen/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Issue - Update reserved member names for new Struct methods.
 * Feature - Add support for Smithy RPC v2 CBOR protocol.
 * Issue - Use `strict_encode64` instead of `encode64`.
 * Issue - Fix builders when `uri` contains empty query parameter.

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -106,22 +106,29 @@ public class RubySymbolProvider implements SymbolProvider,
     }
 
     // Mark all instances methods of a class as reserved. Shape members are accessors of a class.
-    // Taken from "class Foo; end; Foo.new.methods.sort".
-    // Additionally add "each_pair" as we leverage this methods for Type's to_h of Struct.
+    // Taken from "Struct.new.new.methods.sort" using Ruby 3.3
     private static ReservedWords memberReservedNames() {
         ReservedWordsBuilder reservedNames = new ReservedWordsBuilder();
         String[] reserved =
-                {"!", "!=", "!~", "<=>", "==", "===", "=~", "__id__", "__send__", "class", "clone",
-                        "define_singleton_method", "display", "dup", "enum_for", "eql?", "equal?", "extend", "freeze",
-                        "frozen?", "hash", "inspect", "instance_eval", "instance_exec", "instance_of?",
-                        "instance_variable_defined?", "instance_variable_get", "instance_variable_set",
-                        "instance_variables", "is_a?", "itself", "kind_of?", "method", "methods", "nil?", "object_id",
-                        "pretty_inspect", "pretty_print", "pretty_print_cycle", "pretty_print_inspect",
+                {"!", "!=", "!~", "<=>", "==", "===", "[]", "[]=", "__id__", "__send__", "all?", "any?", "chain",
+                        "chunk", "chunk_while", "class", "clone", "collect", "collect_concat", "compact", "count",
+                        "cycle", "deconstruct", "deconstruct_keys", "define_singleton_method", "detect", "dig",
+                        "display", "drop", "drop_while", "dup", "each", "each_cons", "each_entry", "each_pair",
+                        "each_slice", "each_with_index", "each_with_object", "entries", "enum_for", "eql?", "equal?",
+                        "extend", "filter", "filter_map", "find", "find_all", "find_index", "first", "flat_map",
+                        "freeze", "frozen?", "grep", "grep_v", "group_by", "hash", "include?", "inject",
+                        "inspect", "instance_eval", "instance_exec", "instance_of?", "instance_variable_defined?",
+                        "instance_variable_get", "instance_variable_set", "instance_variables", "is_a?", "itself",
+                        "kind_of?", "lazy", "length", "map", "max", "max_by", "member?", "members", "method",
+                        "methods", "min", "min_by", "minmax", "minmax_by", "nil?", "none?", "object_id", "one?",
+                        "partition", "pretty_inspect", "pretty_print", "pretty_print_cycle", "pretty_print_inspect",
                         "pretty_print_instance_variables", "private_methods", "protected_methods", "public_method",
-                        "public_methods", "public_send", "remove_instance_variable", "respond_to?", "send",
-                        "singleton_class", "singleton_method", "singleton_methods", "taint", "tainted?", "tap", "then",
-                        "to_enum", "to_s", "trust", "untaint", "untrust", "untrusted?", "yield_self",
-                        "each_pair" };
+                        "public_methods", "public_send", "reduce", "reject", "remove_instance_variable",
+                        "respond_to?", "reverse_each", "select", "send", "singleton_class", "singleton_method",
+                        "singleton_methods", "size", "slice_after", "slice_before", "slice_when", "sort", "sort_by",
+                        "sum", "take", "take_while", "tally", "tap", "then", "to_a", "to_enum", "to_h", "to_s",
+                        "to_set", "uniq", "values", "values_at", "yield_self", "zip"
+                };
 
         for (String w : reserved) {
             reservedNames.put(w, "member_" + w);


### PR DESCRIPTION
*Description of changes:*
Update reserved member names for new Struct methods (using Ruby 3.3).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
