### PR TITLE
Remove Struct from everything

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/auth.rb
+++ b/codegen/projections/rails_json/lib/rails_json/auth.rb
@@ -9,7 +9,13 @@
 
 module RailsJson
   module Auth
-    Params = Struct.new(:operation_name, keyword_init: true)
+    class Params
+      def initialize(operation_name: nil)
+        @operation_name = operation_name
+      end
+
+      attr_accessor :operation_name
+    end
 
     SCHEMES = [
       Hearth::AuthSchemes::Anonymous.new

--- a/codegen/projections/rails_json/lib/rails_json/config.rb
+++ b/codegen/projections/rails_json/lib/rails_json/config.rb
@@ -91,25 +91,28 @@ module RailsJson
   #   @return [Hearth::Stubs]
   # @!attribute validate_input
   #   @return [Boolean]
-  Config = ::Struct.new(
-    :auth_resolver,
-    :auth_schemes,
-    :disable_host_prefix,
-    :disable_request_compression,
-    :endpoint,
-    :endpoint_resolver,
-    :http_client,
-    :interceptors,
-    :logger,
-    :plugins,
-    :request_min_compression_size_bytes,
-    :retry_strategy,
-    :stub_responses,
-    :stubs,
-    :validate_input,
-    keyword_init: true
-  ) do
+  class Config
     include Hearth::Configuration
+
+    MEMBERS = %i[
+      auth_resolver
+      auth_schemes
+      disable_host_prefix
+      disable_request_compression
+      endpoint
+      endpoint_resolver
+      http_client
+      interceptors
+      logger
+      plugins
+      request_min_compression_size_bytes
+      retry_strategy
+      stub_responses
+      stubs
+      validate_input
+    ].freeze
+
+    attr_accessor(*MEMBERS)
 
     # Validates the configuration.
     def validate!

--- a/codegen/projections/rails_json/lib/rails_json/endpoint.rb
+++ b/codegen/projections/rails_json/lib/rails_json/endpoint.rb
@@ -9,11 +9,12 @@
 
 module RailsJson
   module Endpoint
-    Params = ::Struct.new(
-      :endpoint,
-      keyword_init: true
-    ) do
-      include Hearth::Structure
+    class Params
+      def initialize(endpoint: nil)
+        @endpoint = endpoint
+      end
+
+      attr_accessor :endpoint
     end
 
     class Resolver

--- a/codegen/projections/rails_json/lib/rails_json/plugins/global_config.rb
+++ b/codegen/projections/rails_json/lib/rails_json/plugins/global_config.rb
@@ -17,7 +17,7 @@ module RailsJson
       def call(config)
         options = config.options
         ::Hearth.config.each do |key, value|
-          config[key] = value unless options.key?(key)
+          config.send("#{key}=", value) unless options.key?(key)
         end
       end
 

--- a/codegen/projections/rails_json/sig/rails_json/auth.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/auth.rbs
@@ -9,7 +9,8 @@
 
 module RailsJson
   module Auth
-    class Params < ::Struct[untyped]
+    class Params
+      def initialize: (?operation_name: ::Symbol?) -> void
       attr_accessor operation_name (): ::Symbol
     end
 

--- a/codegen/projections/rails_json/sig/rails_json/config.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/config.rbs
@@ -1,21 +1,21 @@
 module RailsJson
   class Config
     include Hearth::Configuration[instance]
-    attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]
-    attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]
-    attr_accessor disable_host_prefix (): bool
-    attr_accessor disable_request_compression (): bool
-    attr_accessor endpoint (): String
-    attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]
-    attr_accessor http_client (): Hearth::HTTP::Client
-    attr_accessor interceptors (): Hearth::InterceptorList[Config]
-    attr_accessor logger (): Logger
-    attr_accessor plugins (): Hearth::PluginList[Config]
-    attr_accessor request_min_compression_size_bytes (): Integer
-    attr_accessor retry_strategy (): Hearth::_RetryStrategy
-    attr_accessor stub_responses (): bool
-    attr_accessor stubs (): Hearth::Stubs
-    attr_accessor validate_input (): bool
+    attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]?
+    attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]?
+    attr_accessor disable_host_prefix (): bool?
+    attr_accessor disable_request_compression (): bool?
+    attr_accessor endpoint (): String?
+    attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]?
+    attr_accessor http_client (): Hearth::HTTP::Client?
+    attr_accessor interceptors (): Hearth::InterceptorList[Config]?
+    attr_accessor logger (): Logger?
+    attr_accessor plugins (): Hearth::PluginList[Config]?
+    attr_accessor request_min_compression_size_bytes (): Integer?
+    attr_accessor retry_strategy (): Hearth::_RetryStrategy?
+    attr_accessor stub_responses (): bool?
+    attr_accessor stubs (): Hearth::Stubs?
+    attr_accessor validate_input (): bool?
 
     def validate!: () -> void
   end

--- a/codegen/projections/rails_json/sig/rails_json/config.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/config.rbs
@@ -1,7 +1,6 @@
 module RailsJson
-  class Config < ::Struct[untyped]
+  class Config
     include Hearth::Configuration[instance]
-
     attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]
     attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]
     attr_accessor disable_host_prefix (): bool

--- a/codegen/projections/rails_json/sig/rails_json/endpoint.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/endpoint.rbs
@@ -11,7 +11,7 @@ module RailsJson
   module Endpoint
     class Params
       def initialize: (?endpoint: ::String?) -> void
-      attr_accessor endpoint (): ::String
+      attr_accessor endpoint (): ::String?
     end
 
     class Resolver

--- a/codegen/projections/rails_json/sig/rails_json/endpoint.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/endpoint.rbs
@@ -9,8 +9,9 @@
 
 module RailsJson
   module Endpoint
-    class Params < ::Struct[untyped]
-      attr_accessor endpoint: ::String
+    class Params
+      def initialize: (?endpoint: ::String?) -> void
+      attr_accessor endpoint (): ::String
     end
 
     class Resolver

--- a/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/auth.rb
+++ b/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/auth.rb
@@ -9,7 +9,13 @@
 
 module Rpcv2Cbor
   module Auth
-    Params = Struct.new(:operation_name, keyword_init: true)
+    class Params
+      def initialize(operation_name: nil)
+        @operation_name = operation_name
+      end
+
+      attr_accessor :operation_name
+    end
 
     SCHEMES = [
       Hearth::AuthSchemes::Anonymous.new

--- a/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/config.rb
+++ b/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/config.rb
@@ -82,23 +82,26 @@ module Rpcv2Cbor
   #   @return [Hearth::Stubs]
   # @!attribute validate_input
   #   @return [Boolean]
-  Config = ::Struct.new(
-    :auth_resolver,
-    :auth_schemes,
-    :disable_host_prefix,
-    :endpoint,
-    :endpoint_resolver,
-    :http_client,
-    :interceptors,
-    :logger,
-    :plugins,
-    :retry_strategy,
-    :stub_responses,
-    :stubs,
-    :validate_input,
-    keyword_init: true
-  ) do
+  class Config
     include Hearth::Configuration
+
+    MEMBERS = %i[
+      auth_resolver
+      auth_schemes
+      disable_host_prefix
+      endpoint
+      endpoint_resolver
+      http_client
+      interceptors
+      logger
+      plugins
+      retry_strategy
+      stub_responses
+      stubs
+      validate_input
+    ].freeze
+
+    attr_accessor(*MEMBERS)
 
     # Validates the configuration.
     def validate!

--- a/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/endpoint.rb
+++ b/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/endpoint.rb
@@ -9,11 +9,12 @@
 
 module Rpcv2Cbor
   module Endpoint
-    Params = ::Struct.new(
-      :endpoint,
-      keyword_init: true
-    ) do
-      include Hearth::Structure
+    class Params
+      def initialize(endpoint: nil)
+        @endpoint = endpoint
+      end
+
+      attr_accessor :endpoint
     end
 
     class Resolver

--- a/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/plugins/global_config.rb
+++ b/codegen/projections/rpcv2_cbor/lib/rpcv2_cbor/plugins/global_config.rb
@@ -17,7 +17,7 @@ module Rpcv2Cbor
       def call(config)
         options = config.options
         ::Hearth.config.each do |key, value|
-          config[key] = value unless options.key?(key)
+          config.send("#{key}=", value) unless options.key?(key)
         end
       end
 

--- a/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/auth.rbs
+++ b/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/auth.rbs
@@ -9,7 +9,8 @@
 
 module Rpcv2Cbor
   module Auth
-    class Params < ::Struct[untyped]
+    class Params
+      def initialize: (?operation_name: ::Symbol?) -> void
       attr_accessor operation_name (): ::Symbol
     end
 

--- a/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/config.rbs
+++ b/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/config.rbs
@@ -1,19 +1,19 @@
 module Rpcv2Cbor
   class Config
     include Hearth::Configuration[instance]
-    attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]
-    attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]
-    attr_accessor disable_host_prefix (): bool
-    attr_accessor endpoint (): String
-    attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]
-    attr_accessor http_client (): Hearth::HTTP::Client
-    attr_accessor interceptors (): Hearth::InterceptorList[Config]
-    attr_accessor logger (): Logger
-    attr_accessor plugins (): Hearth::PluginList[Config]
-    attr_accessor retry_strategy (): Hearth::_RetryStrategy
-    attr_accessor stub_responses (): bool
-    attr_accessor stubs (): Hearth::Stubs
-    attr_accessor validate_input (): bool
+    attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]?
+    attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]?
+    attr_accessor disable_host_prefix (): bool?
+    attr_accessor endpoint (): String?
+    attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]?
+    attr_accessor http_client (): Hearth::HTTP::Client?
+    attr_accessor interceptors (): Hearth::InterceptorList[Config]?
+    attr_accessor logger (): Logger?
+    attr_accessor plugins (): Hearth::PluginList[Config]?
+    attr_accessor retry_strategy (): Hearth::_RetryStrategy?
+    attr_accessor stub_responses (): bool?
+    attr_accessor stubs (): Hearth::Stubs?
+    attr_accessor validate_input (): bool?
 
     def validate!: () -> void
   end

--- a/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/config.rbs
+++ b/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/config.rbs
@@ -1,7 +1,6 @@
 module Rpcv2Cbor
-  class Config < ::Struct[untyped]
+  class Config
     include Hearth::Configuration[instance]
-
     attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]
     attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]
     attr_accessor disable_host_prefix (): bool

--- a/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/endpoint.rbs
+++ b/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/endpoint.rbs
@@ -9,8 +9,9 @@
 
 module Rpcv2Cbor
   module Endpoint
-    class Params < ::Struct[untyped]
-      attr_accessor endpoint: ::String
+    class Params
+      def initialize: (?endpoint: ::String?) -> void
+      attr_accessor endpoint (): ::String
     end
 
     class Resolver

--- a/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/endpoint.rbs
+++ b/codegen/projections/rpcv2_cbor/sig/rpcv2_cbor/endpoint.rbs
@@ -11,7 +11,7 @@ module Rpcv2Cbor
   module Endpoint
     class Params
       def initialize: (?endpoint: ::String?) -> void
-      attr_accessor endpoint (): ::String
+      attr_accessor endpoint (): ::String?
     end
 
     class Resolver

--- a/codegen/projections/white_label/lib/white_label/auth.rb
+++ b/codegen/projections/white_label/lib/white_label/auth.rb
@@ -11,7 +11,14 @@ require_relative 'auth/http_custom_auth'
 
 module WhiteLabel
   module Auth
-    Params = Struct.new(:custom_param, :operation_name, keyword_init: true)
+    class Params
+      def initialize(custom_param: nil, operation_name: nil)
+        @custom_param = custom_param
+        @operation_name = operation_name
+      end
+
+      attr_accessor :custom_param, :operation_name
+    end
 
     SCHEMES = [
       Hearth::AuthSchemes::HTTPApiKey.new,

--- a/codegen/projections/white_label/lib/white_label/config.rb
+++ b/codegen/projections/white_label/lib/white_label/config.rb
@@ -115,31 +115,34 @@ module WhiteLabel
   #   @return [String]
   # @!attribute validate_input
   #   @return [Boolean]
-  Config = ::Struct.new(
-    :auth_resolver,
-    :auth_schemes,
-    :disable_host_prefix,
-    :disable_request_compression,
-    :endpoint,
-    :endpoint_resolver,
-    :http_api_key_provider,
-    :http_bearer_provider,
-    :http_client,
-    :http_custom_key_provider,
-    :http_login_provider,
-    :interceptors,
-    :logger,
-    :plugins,
-    :request_min_compression_size_bytes,
-    :retry_strategy,
-    :stage,
-    :stub_responses,
-    :stubs,
-    :test_config,
-    :validate_input,
-    keyword_init: true
-  ) do
+  class Config
     include Hearth::Configuration
+
+    MEMBERS = %i[
+      auth_resolver
+      auth_schemes
+      disable_host_prefix
+      disable_request_compression
+      endpoint
+      endpoint_resolver
+      http_api_key_provider
+      http_bearer_provider
+      http_client
+      http_custom_key_provider
+      http_login_provider
+      interceptors
+      logger
+      plugins
+      request_min_compression_size_bytes
+      retry_strategy
+      stage
+      stub_responses
+      stubs
+      test_config
+      validate_input
+    ].freeze
+
+    attr_accessor(*MEMBERS)
 
     # Validates the configuration.
     def validate!

--- a/codegen/projections/white_label/lib/white_label/endpoint.rb
+++ b/codegen/projections/white_label/lib/white_label/endpoint.rb
@@ -9,14 +9,15 @@
 
 module WhiteLabel
   module Endpoint
-    Params = ::Struct.new(
-      :stage,
-      :dataplane,
-      :resource_url,
-      :endpoint,
-      keyword_init: true
-    ) do
-      include Hearth::Structure
+    class Params
+      def initialize(stage: nil, dataplane: nil, resource_url: nil, endpoint: nil)
+        @stage = stage
+        @dataplane = dataplane
+        @resource_url = resource_url
+        @endpoint = endpoint
+      end
+
+      attr_accessor :stage, :dataplane, :resource_url, :endpoint
     end
 
     class Resolver

--- a/codegen/projections/white_label/lib/white_label/plugins/global_config.rb
+++ b/codegen/projections/white_label/lib/white_label/plugins/global_config.rb
@@ -17,7 +17,7 @@ module WhiteLabel
       def call(config)
         options = config.options
         ::Hearth.config.each do |key, value|
-          config[key] = value unless options.key?(key)
+          config.send("#{key}=", value) unless options.key?(key)
         end
       end
 

--- a/codegen/projections/white_label/sig/white_label/auth.rbs
+++ b/codegen/projections/white_label/sig/white_label/auth.rbs
@@ -9,7 +9,8 @@
 
 module WhiteLabel
   module Auth
-    class Params < ::Struct[untyped]
+    class Params
+      def initialize: (?custom_param: ::String?, ?operation_name: ::Symbol?) -> void
       attr_accessor custom_param (): ::String
       attr_accessor operation_name (): ::Symbol
     end

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -23,7 +23,7 @@ module WhiteLabel
         ?http_api_key_provider: Hearth::IdentityProvider,
         ?http_bearer_provider: Hearth::IdentityProvider,
         ?http_client: Hearth::HTTP::Client,
-        ?http_custom_key_provider: untyped,
+        ?http_custom_key_provider: Hearth::IdentityProvider,
         ?http_login_provider: Hearth::IdentityProvider,
         ?interceptors: Hearth::InterceptorList[Config],
         ?logger: Logger,

--- a/codegen/projections/white_label/sig/white_label/config.rbs
+++ b/codegen/projections/white_label/sig/white_label/config.rbs
@@ -1,7 +1,6 @@
 module WhiteLabel
-  class Config < ::Struct[untyped]
+  class Config
     include Hearth::Configuration[instance]
-
     attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]
     attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]
     attr_accessor disable_host_prefix (): bool

--- a/codegen/projections/white_label/sig/white_label/config.rbs
+++ b/codegen/projections/white_label/sig/white_label/config.rbs
@@ -1,27 +1,27 @@
 module WhiteLabel
   class Config
     include Hearth::Configuration[instance]
-    attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]
-    attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]
-    attr_accessor disable_host_prefix (): bool
-    attr_accessor disable_request_compression (): bool
-    attr_accessor endpoint (): String
-    attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]
-    attr_accessor http_api_key_provider (): Hearth::IdentityProvider
-    attr_accessor http_bearer_provider (): Hearth::IdentityProvider
-    attr_accessor http_client (): Hearth::HTTP::Client
-    attr_accessor http_custom_key_provider (): untyped
-    attr_accessor http_login_provider (): Hearth::IdentityProvider
-    attr_accessor interceptors (): Hearth::InterceptorList[Config]
-    attr_accessor logger (): Logger
-    attr_accessor plugins (): Hearth::PluginList[Config]
-    attr_accessor request_min_compression_size_bytes (): Integer
-    attr_accessor retry_strategy (): Hearth::_RetryStrategy
-    attr_accessor stage (): String
-    attr_accessor stub_responses (): bool
-    attr_accessor stubs (): Hearth::Stubs
-    attr_accessor test_config (): untyped
-    attr_accessor validate_input (): bool
+    attr_accessor auth_resolver (): Hearth::_AuthResolver[Auth::Params]?
+    attr_accessor auth_schemes (): Array[Hearth::AuthSchemes::Base]?
+    attr_accessor disable_host_prefix (): bool?
+    attr_accessor disable_request_compression (): bool?
+    attr_accessor endpoint (): String?
+    attr_accessor endpoint_resolver (): Hearth::_EndpointResolver[Endpoint::Params]?
+    attr_accessor http_api_key_provider (): Hearth::IdentityProvider?
+    attr_accessor http_bearer_provider (): Hearth::IdentityProvider?
+    attr_accessor http_client (): Hearth::HTTP::Client?
+    attr_accessor http_custom_key_provider (): Hearth::IdentityProvider?
+    attr_accessor http_login_provider (): Hearth::IdentityProvider?
+    attr_accessor interceptors (): Hearth::InterceptorList[Config]?
+    attr_accessor logger (): Logger?
+    attr_accessor plugins (): Hearth::PluginList[Config]?
+    attr_accessor request_min_compression_size_bytes (): Integer?
+    attr_accessor retry_strategy (): Hearth::_RetryStrategy?
+    attr_accessor stage (): String?
+    attr_accessor stub_responses (): bool?
+    attr_accessor stubs (): Hearth::Stubs?
+    attr_accessor test_config (): untyped?
+    attr_accessor validate_input (): bool?
 
     def validate!: () -> void
   end

--- a/codegen/projections/white_label/sig/white_label/endpoint.rbs
+++ b/codegen/projections/white_label/sig/white_label/endpoint.rbs
@@ -9,11 +9,12 @@
 
 module WhiteLabel
   module Endpoint
-    class Params < ::Struct[untyped]
-      attr_accessor dataplane: bool
-      attr_accessor resource_url: ::String
-      attr_accessor endpoint: ::String
-      attr_accessor stage: ::String
+    class Params
+      def initialize: (?dataplane: bool?, ?resource_url: ::String?, ?endpoint: ::String?, ?stage: ::String?) -> void
+      attr_accessor dataplane (): bool
+      attr_accessor resource_url (): ::String
+      attr_accessor endpoint (): ::String
+      attr_accessor stage (): ::String
     end
 
     class Resolver

--- a/codegen/projections/white_label/sig/white_label/endpoint.rbs
+++ b/codegen/projections/white_label/sig/white_label/endpoint.rbs
@@ -11,10 +11,10 @@ module WhiteLabel
   module Endpoint
     class Params
       def initialize: (?dataplane: bool?, ?resource_url: ::String?, ?endpoint: ::String?, ?stage: ::String?) -> void
-      attr_accessor dataplane (): bool
-      attr_accessor resource_url (): ::String
-      attr_accessor endpoint (): ::String
-      attr_accessor stage (): ::String
+      attr_accessor dataplane (): bool?
+      attr_accessor resource_url (): ::String?
+      attr_accessor endpoint (): ::String?
+      attr_accessor stage (): ::String?
     end
 
     class Resolver

--- a/codegen/projections/white_label/spec/auth_spec.rb
+++ b/codegen/projections/white_label/spec/auth_spec.rb
@@ -158,7 +158,7 @@ module WhiteLabel
   end
 
   describe Config do
-    it 'validates identity resolvers' do
+    it 'validates identity resolvers', rbs_test: :skip do
       msg = /to be in \[Hearth::IdentityProvider\], got String/
       expect do
         Config.new(http_api_key_provider: 'foo').validate!

--- a/codegen/projections/white_label/spec/client_spec.rb
+++ b/codegen/projections/white_label/spec/client_spec.rb
@@ -19,7 +19,7 @@ module WhiteLabel
       client.kitchen_sink
     end
 
-    it 'validates config' do
+    it 'validates config', rbs_test: :skip do
       expect do
         Client.new(stub_responses: 'false')
       end.to raise_error(ArgumentError, /config\[:stub_responses\]/)
@@ -34,7 +34,7 @@ module WhiteLabel
         expect(client.config.logger).to eq(logger)
       end
 
-      it 'validates global config values' do
+      it 'validates global config values', rbs_test: :skip do
         Hearth.config[:logger] = 'logger'
         expect do
           Client.new
@@ -50,7 +50,7 @@ module WhiteLabel
     end
 
     context 'operation overrides' do
-      it 'validates config' do
+      it 'validates config', rbs_test: :skip do
         expect do
           client.kitchen_sink({}, endpoint: 1)
         end.to raise_error(ArgumentError, /config\[:endpoint\]/)

--- a/codegen/projections/white_label/spec/compression_spec.rb
+++ b/codegen/projections/white_label/spec/compression_spec.rb
@@ -5,7 +5,7 @@ require_relative 'spec_helper'
 module WhiteLabel
   describe Config do
     context 'disable_request_compression' do
-      it 'raises error when given an invalid input' do
+      it 'raises when given an invalid input', rbs_test: :skip do
         expect { Config.new(disable_request_compression: 'string').validate! }
           .to raise_error(
             ArgumentError,
@@ -16,7 +16,7 @@ module WhiteLabel
     end
 
     context 'request_min_compression_size_bytes' do
-      it 'raises error when given invalid integer' do
+      it 'raises when given invalid integer' do
         expect { Config.new(request_min_compression_size_bytes: -1).validate! }
           .to raise_error(
             ArgumentError,

--- a/codegen/projections/white_label/spec/config_spec.rb
+++ b/codegen/projections/white_label/spec/config_spec.rb
@@ -31,7 +31,7 @@ module WhiteLabel
         expect(config.request_min_compression_size_bytes).to be_a(Integer)
       end
 
-      it 'validates types' do
+      it 'validates types', rbs_test: :skip do
         config = Config.new(logger: 'foo')
         expect { config.validate! }
           .to raise_error(ArgumentError, /config\[:logger\]/)

--- a/codegen/projections/white_label/spec/config_spec.rb
+++ b/codegen/projections/white_label/spec/config_spec.rb
@@ -39,7 +39,7 @@ module WhiteLabel
 
       it 'raises on unknown keys' do
         expect { Config.new(foo: 'bar') }
-          .to raise_error(ArgumentError, /unknown keywords: foo/)
+          .to raise_error(ArgumentError, /config\[:foo\]/)
       end
     end
   end

--- a/codegen/projections/white_label/spec/endpoint_spec.rb
+++ b/codegen/projections/white_label/spec/endpoint_spec.rb
@@ -28,7 +28,8 @@ module WhiteLabel
           endpoint = subject.resolve(params)
           expect(endpoint.uri).to eq(expected[:url])
           expect(endpoint.headers).to eq(expected[:headers])
-          expect(endpoint.auth_schemes).to eq(expected[:auth_schemes])
+          expect(endpoint.auth_schemes.map(&:scheme_id)).to eq(expected[:auth_schemes].map(&:scheme_id))
+          expect(endpoint.auth_schemes.map(&:properties)).to eq(expected[:auth_schemes].map(&:properties))
         end
 
         it 'produces the correct output from the client when calling endpoint_operation' do
@@ -67,7 +68,8 @@ module WhiteLabel
           endpoint = subject.resolve(params)
           expect(endpoint.uri).to eq(expected[:url])
           expect(endpoint.headers).to eq(expected[:headers])
-          expect(endpoint.auth_schemes).to eq(expected[:auth_schemes])
+          expect(endpoint.auth_schemes.map(&:scheme_id)).to eq(expected[:auth_schemes].map(&:scheme_id))
+          expect(endpoint.auth_schemes.map(&:properties)).to eq(expected[:auth_schemes].map(&:properties))
         end
       end
 
@@ -98,7 +100,8 @@ module WhiteLabel
           endpoint = subject.resolve(params)
           expect(endpoint.uri).to eq(expected[:url])
           expect(endpoint.headers).to eq(expected[:headers])
-          expect(endpoint.auth_schemes).to eq(expected[:auth_schemes])
+          expect(endpoint.auth_schemes.map(&:scheme_id)).to eq(expected[:auth_schemes].map(&:scheme_id))
+          expect(endpoint.auth_schemes.map(&:properties)).to eq(expected[:auth_schemes].map(&:properties))
         end
 
         it 'produces the correct output from the client when calling endpoint_operation' do
@@ -136,7 +139,8 @@ module WhiteLabel
           endpoint = subject.resolve(params)
           expect(endpoint.uri).to eq(expected[:url])
           expect(endpoint.headers).to eq(expected[:headers])
-          expect(endpoint.auth_schemes).to eq(expected[:auth_schemes])
+          expect(endpoint.auth_schemes.map(&:scheme_id)).to eq(expected[:auth_schemes].map(&:scheme_id))
+          expect(endpoint.auth_schemes.map(&:properties)).to eq(expected[:auth_schemes].map(&:properties))
         end
 
         it 'produces the correct output from the client when calling resource_endpoint' do
@@ -176,7 +180,8 @@ module WhiteLabel
           endpoint = subject.resolve(params)
           expect(endpoint.uri).to eq(expected[:url])
           expect(endpoint.headers).to eq(expected[:headers])
-          expect(endpoint.auth_schemes).to eq(expected[:auth_schemes])
+          expect(endpoint.auth_schemes.map(&:scheme_id)).to eq(expected[:auth_schemes].map(&:scheme_id))
+          expect(endpoint.auth_schemes.map(&:properties)).to eq(expected[:auth_schemes].map(&:properties))
         end
 
         it 'produces the correct output from the client when calling dataplane_endpoint' do

--- a/codegen/smithy-ruby-codegen-test-utils/src/main/java/software/amazon/smithy/ruby/codegen/integrations/WhiteLabelTestIntegration.java
+++ b/codegen/smithy-ruby-codegen-test-utils/src/main/java/software/amazon/smithy/ruby/codegen/integrations/WhiteLabelTestIntegration.java
@@ -117,6 +117,7 @@ public class WhiteLabelTestIntegration implements RubyIntegration {
                                 identityType,
                                 HttpBasicAuthTrait.ID))
                 .documentationType(Hearth.IDENTITY_PROVIDER.toString())
+                .rbsType(Hearth.IDENTITY_PROVIDER.toString())
                 .defaultDynamicValue(defaultConfigValue)
                 .constraint(new TypeConstraint(Hearth.IDENTITY_PROVIDER.toString()))
                 .build();

--- a/codegen/smithy-ruby-codegen-test/integration-specs/auth_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/auth_spec.rb
@@ -158,7 +158,7 @@ module WhiteLabel
   end
 
   describe Config do
-    it 'validates identity resolvers' do
+    it 'validates identity resolvers', rbs_test: :skip do
       msg = /to be in \[Hearth::IdentityProvider\], got String/
       expect do
         Config.new(http_api_key_provider: 'foo').validate!

--- a/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
@@ -19,7 +19,7 @@ module WhiteLabel
       client.kitchen_sink
     end
 
-    it 'validates config' do
+    it 'validates config', rbs_test: :skip do
       expect do
         Client.new(stub_responses: 'false')
       end.to raise_error(ArgumentError, /config\[:stub_responses\]/)
@@ -34,7 +34,7 @@ module WhiteLabel
         expect(client.config.logger).to eq(logger)
       end
 
-      it 'validates global config values' do
+      it 'validates global config values', rbs_test: :skip do
         Hearth.config[:logger] = 'logger'
         expect do
           Client.new
@@ -50,7 +50,7 @@ module WhiteLabel
     end
 
     context 'operation overrides' do
-      it 'validates config' do
+      it 'validates config', rbs_test: :skip do
         expect do
           client.kitchen_sink({}, endpoint: 1)
         end.to raise_error(ArgumentError, /config\[:endpoint\]/)

--- a/codegen/smithy-ruby-codegen-test/integration-specs/compression_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/compression_spec.rb
@@ -5,7 +5,7 @@ require_relative 'spec_helper'
 module WhiteLabel
   describe Config do
     context 'disable_request_compression' do
-      it 'raises error when given an invalid input' do
+      it 'raises when given an invalid input', rbs_test: :skip do
         expect { Config.new(disable_request_compression: 'string').validate! }
           .to raise_error(
             ArgumentError,
@@ -16,7 +16,7 @@ module WhiteLabel
     end
 
     context 'request_min_compression_size_bytes' do
-      it 'raises error when given invalid integer' do
+      it 'raises when given invalid integer' do
         expect { Config.new(request_min_compression_size_bytes: -1).validate! }
           .to raise_error(
             ArgumentError,

--- a/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
@@ -31,7 +31,7 @@ module WhiteLabel
         expect(config.request_min_compression_size_bytes).to be_a(Integer)
       end
 
-      it 'validates types' do
+      it 'validates types', rbs_test: :skip do
         config = Config.new(logger: 'foo')
         expect { config.validate! }
           .to raise_error(ArgumentError, /config\[:logger\]/)

--- a/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
@@ -39,7 +39,7 @@ module WhiteLabel
 
       it 'raises on unknown keys' do
         expect { Config.new(foo: 'bar') }
-          .to raise_error(ArgumentError, /unknown keywords: foo/)
+          .to raise_error(ArgumentError, /config\[:foo\]/)
       end
     end
   end

--- a/codegen/smithy-ruby-codegen/CHANGELOG.md
+++ b/codegen/smithy-ruby-codegen/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Remove `Struct` from generated Types.
+* Issue - Remove `Struct` from generated Types, Config, and other places to allow for better RBS typing as well as less reserved words.
 * Feature - Add support for stringArray Endpoint parameters + operationContextParams binding.
 * Issue - Update reserved member names for new Struct methods.
 * Feature - Add support for Smithy RPC v2 CBOR protocol.

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
@@ -103,7 +103,7 @@ public class ConfigGenerator extends RubyGeneratorBase {
                         clientConfigList.forEach((clientConfig) -> {
                             String member = RubySymbolProvider.toMemberName(clientConfig.getName());
                             String rbsType = clientConfig.getRbsType();
-                            writer.write("attr_accessor $L (): $L", member, rbsType);
+                            writer.write("attr_accessor $L (): $L?", member, rbsType);
                         });
                     })
                     .write("")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -230,7 +230,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
         Map<String, String> defaultParams = new LinkedHashMap<>();
         endpointRuleSet.getParameters().forEach((parameter -> {
             String rubyParamName = RubyFormatter.toSnakeCase(parameter.getName().getName().getValue());
-            params.add(RubyFormatter.asSymbol(rubyParamName));
+            params.add(rubyParamName);
             if (parameter.getDefault().isPresent()) {
                 if (parameter.getType() == ParameterType.STRING) {
                     defaultParams.put(rubyParamName,
@@ -250,29 +250,26 @@ public class EndpointGenerator extends RubyGeneratorBase {
         }));
 
         writer
-                .openBlock("Params = ::Struct.new(")
-                .write(String.join(",\n", params) + ", ")
-                .write("keyword_init: true")
-                .closeBlock(") do")
-                .indent()
-                .write("include $T", Hearth.STRUCTURE)
+                .openBlock("class Params")
+                .openBlock("def initialize($L)", params.stream()
+                        .map(p -> "%s: nil".formatted(RubyFormatter.toSnakeCase(p)))
+                        .collect(Collectors.joining(", ")))
                 .call(() -> {
-                    if (!defaultParams.isEmpty()) {
-                        writer
-                                .write("")
-                                .openBlock("def initialize(*)")
-                                .write("super")
-                                .call(() -> {
-                                    defaultParams.forEach((param, defaultValue) -> {
-                                        writer.write("self.$1L = $2L if self.$1L.nil?",
-                                                param,
-                                                defaultValue);
-                                    });
-                                })
-                                .closeBlock("end");
-                    }
-
+                    params.forEach(p -> {
+                        String endpointParam = RubyFormatter.toSnakeCase(p);
+                        if (defaultParams.containsKey(endpointParam)) {
+                            writer.write("@$1L = $1L.nil? ? $2L : $1L",
+                                    endpointParam, defaultParams.get(endpointParam));
+                        } else {
+                            writer.write("@$L = $L", endpointParam, endpointParam);
+                        }
+                    });
                 })
+                .closeBlock("end")
+                .write("")
+                .write("attr_accessor $L", params.stream()
+                        .map(p -> RubyFormatter.asSymbol(p))
+                        .collect(Collectors.joining(", ")))
                 .closeBlock("end");
     }
 
@@ -292,10 +289,14 @@ public class EndpointGenerator extends RubyGeneratorBase {
         }));
 
         writer
-                .openBlock("class Params < ::Struct[untyped]")
+                .openBlock("class Params")
+                .write("def initialize: ($L) -> void",
+                        paramsToTypes.entrySet().stream()
+                                .map(e -> "?%s: %s?".formatted(e.getKey(), e.getValue()))
+                                .collect(Collectors.joining(", ")))
                 .call(() -> {
                     paramsToTypes.forEach((param, rbsType) -> {
-                        writer.write("attr_accessor $L: $L", param, rbsType);
+                        writer.write("attr_accessor $L (): $L", param, rbsType);
                     });
                 })
                 .closeBlock("end");

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -296,7 +296,7 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                 .collect(Collectors.joining(", ")))
                 .call(() -> {
                     paramsToTypes.forEach((param, rbsType) -> {
-                        writer.write("attr_accessor $L (): $L", param, rbsType);
+                        writer.write("attr_accessor $L (): $L?", param, rbsType);
                     });
                 })
                 .closeBlock("end");

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -519,7 +519,10 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                     .write("endpoint = subject.resolve(params)")
                                     .write("expect(endpoint.uri).to eq(expected[:url])")
                                     .write("expect(endpoint.headers).to eq(expected[:headers])")
-                                    .write("expect(endpoint.auth_schemes).to eq(expected[:auth_schemes])");
+                                    .write("expect(endpoint.auth_schemes.map(&:scheme_id).to "
+                                            + "eq(expected[:auth_schemes].map(&:scheme_id))")
+                                    .write("expect(endpoint.auth_schemes.map(&:properties).to "
+                                            + "eq(expected[:auth_schemes].map(&:properties))");
                         }
                     })
                     .closeBlock("end") // end main test case it block

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/EndpointGenerator.java
@@ -519,9 +519,9 @@ public class EndpointGenerator extends RubyGeneratorBase {
                                     .write("endpoint = subject.resolve(params)")
                                     .write("expect(endpoint.uri).to eq(expected[:url])")
                                     .write("expect(endpoint.headers).to eq(expected[:headers])")
-                                    .write("expect(endpoint.auth_schemes.map(&:scheme_id).to "
+                                    .write("expect(endpoint.auth_schemes.map(&:scheme_id)).to "
                                             + "eq(expected[:auth_schemes].map(&:scheme_id))")
-                                    .write("expect(endpoint.auth_schemes.map(&:properties).to "
+                                    .write("expect(endpoint.auth_schemes.map(&:properties)).to "
                                             + "eq(expected[:auth_schemes].map(&:properties))");
                         }
                     })

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/GlobalConfigPluginGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/GlobalConfigPluginGenerator.java
@@ -75,7 +75,7 @@ public class GlobalConfigPluginGenerator extends RubyGeneratorBase {
                 .openBlock("def call(config)")
                 .write("options = config.options")
                 .openBlock("$T.config.each do |key, value|", Hearth.HEARTH)
-                .write("config[key] = value unless options.key?(key)")
+                .write("config.send(\"#{key}=\", value) unless options.key?(key)")
                 .closeBlock("end")
                 .closeBlock("end");
     }

--- a/hearth/CHANGELOG.md
+++ b/hearth/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Remove `Struct` from generated Types.
+* Issue - Remove `Struct` from generated Types, Config, and other places to allow for better RBS typing as well as less reserved words.
 * Feature - Add `Hearth::Cbor.encode` and `Hearth::Cbor.decode`.
 * Issue - Fix query param `to_s` for empty arrays.
 * Feature - [Breaking Change] Add `config` to `Hearth::Context` and refactor `logger` and `interceptors` inside of it.

--- a/hearth/lib/hearth/cbor.rb
+++ b/hearth/lib/hearth/cbor.rb
@@ -13,16 +13,22 @@ module Hearth
     # A Tag consists of a tag number and a value.
     # In the extended generic data model, a tag number's definition
     # describes the additional semantics conveyed with the tag number.
-    # # @!method initialize(*args)
-    #   @option args [Integer] :tag The tag number.
-    #   @option args [Object] :value The tag's content.
-    # @!attribute tag
-    #   The tag number.
-    #   @return [Integer]
-    # @!attribute value
-    #   The tag's content.
-    #   @return [Object]
-    Tagged = Struct.new(:tag, :value)
+    class Tagged
+      # @param [Integer] :tag The tag number.
+      # @param [Object] :value The tag's content.
+      def initialize(tag:, value:)
+        @tag = tag
+        @value = value
+      end
+
+      # The tag number.
+      # @return [Integer]
+      attr_accessor :tag
+
+      # The tag's content.
+      # @return [Object]
+      attr_accessor :value
+    end
 
     # Generic Cbor error, super class for specific encode/decode related errors.
     class Error < StandardError; end

--- a/hearth/lib/hearth/cbor/decoder.rb
+++ b/hearth/lib/hearth/cbor/decoder.rb
@@ -72,7 +72,7 @@ module Hearth
           when TAG_TYPE_BIGDEC
             read_big_decimal
           else
-            Tagged.new(tag, decode_item)
+            Tagged.new(tag: tag, value: decode_item)
           end
         when :break_stop_code
           raise UnexpectedBreakCodeError

--- a/hearth/lib/hearth/config/resolver.rb
+++ b/hearth/lib/hearth/config/resolver.rb
@@ -7,10 +7,10 @@ module Hearth
     class Resolver
       private_class_method :new
 
-      # @param config [Struct]
+      # @param config [Configuration]
       # @param options [Hash]
       # @param defaults [Hash<Array<Proc>>]
-      # @return [Struct]
+      # @return [Configuration]
       def self.resolve(config, options, defaults = {})
         new(config).send(:resolve, options, defaults)
       end
@@ -30,8 +30,8 @@ module Hearth
       def resolve(options, defaults)
         @options = options
         @defaults = defaults
-        @config.members.each do |key|
-          @config[key] = self[key]
+        @config.class::MEMBERS.each do |key|
+          @config.send("#{key}=", self[key])
         end
       end
 

--- a/hearth/lib/hearth/configuration.rb
+++ b/hearth/lib/hearth/configuration.rb
@@ -15,8 +15,7 @@ module Hearth
     # @return [Hash<Symbol, Object>] The configuration options.
     def to_h(obj = self)
       obj.class::MEMBERS.each_with_object({}) do |member, hash|
-        value = obj.send(member)
-        hash[member] = value
+        hash[member] = obj.send(member)
       end
     end
     alias to_hash to_h

--- a/hearth/lib/hearth/configuration.rb
+++ b/hearth/lib/hearth/configuration.rb
@@ -5,12 +5,21 @@ module Hearth
   module Configuration
     def initialize(**options)
       @options = options.dup
+      Hearth::Validator.validate_unknown!(self, options, context: 'config')
       Hearth::Config::Resolver.resolve(self, options, _defaults)
-      super
     end
 
     # @return [Hash<Symbol, Object>] The original configuration options.
     attr_reader :options
+
+    # @return [Hash<Symbol, Object>] The configuration options.
+    def to_h(obj = self)
+      obj.class::MEMBERS.each_with_object({}) do |member, hash|
+        value = obj.send(member)
+        hash[member] = value
+      end
+    end
+    alias to_hash to_h
 
     def merge(configuration)
       self.class.new(**to_h.merge(configuration.to_h))

--- a/hearth/lib/hearth/dns/host_address.rb
+++ b/hearth/lib/hearth/dns/host_address.rb
@@ -3,25 +3,28 @@
 module Hearth
   module DNS
     # Address results from a DNS lookup in {HostResolver}.
-    # @!method initialize(*args)
-    #   @option args [Symbol] :address_type The type of address. For example,
-    #    :A or :AAAA.
-    #   @option args [String] :address The IP address.
-    #   @option args [String] :hostname The hostname that was resolved.
-    # @!attribute address_type
-    #   The type of address. For example, :A or :AAAA.
-    #   @return [Symbol]
-    # @!attribute address
-    #   The IP address.
-    #   @return [String]
-    # @!attribute hostname
-    #   The hostname that was resolved.
-    #   @return [String]
-    HostAddress = Struct.new(
-      :address_type,
-      :address,
-      :hostname,
-      keyword_init: true
-    )
+    class HostAddress
+      # @param [Symbol] :address_type The type of address. For example,
+      #  :A or :AAAA.
+      # @param [String] :address The IP address.
+      # @param [String] :hostname The hostname that was resolved.
+      def initialize(address_type:, address:, hostname:)
+        @address_type = address_type
+        @address = address
+        @hostname = hostname
+      end
+
+      # The type of address. For example, :A or :AAAA.
+      # @return [Symbol]
+      attr_accessor :address_type
+
+      # The IP address.
+      # @return [String]
+      attr_accessor :address
+
+      # The hostname that was resolved.
+      # @return [String]
+      attr_accessor :hostname
+    end
   end
 end

--- a/hearth/lib/hearth/endpoint_rules.rb
+++ b/hearth/lib/hearth/endpoint_rules.rb
@@ -26,11 +26,6 @@ module Hearth
       # Additional properties of the authentication scheme.
       # @return [Hash]
       attr_accessor :properties
-
-      # @return [Boolean]
-      def ==(other)
-        scheme_id == other.scheme_id && properties == other.properties
-      end
     end
 
     # An Endpoint resolved by an EndpointProvider

--- a/hearth/lib/hearth/endpoint_rules.rb
+++ b/hearth/lib/hearth/endpoint_rules.rb
@@ -26,6 +26,11 @@ module Hearth
       # Additional properties of the authentication scheme.
       # @return [Hash]
       attr_accessor :properties
+
+      # @return [Boolean]
+      def ==(other)
+        scheme_id == other.scheme_id && properties == other.properties
+      end
     end
 
     # An Endpoint resolved by an EndpointProvider

--- a/hearth/lib/hearth/endpoint_rules.rb
+++ b/hearth/lib/hearth/endpoint_rules.rb
@@ -11,49 +11,45 @@ module Hearth
   # invoked without additional dependencies, called the standard library.
   module EndpointRules
     # An Authentication Scheme supported by an Endpoint
-    # @!attribute scheme_id
-    #   The identifier of the authentication scheme.
-    #   @return [String]
-    # @!attribute properties
-    #   Additional properties of the authentication scheme.
-    #   @return [Hash]
-    AuthScheme = Struct.new(
-      :scheme_id,
-      :properties,
-      keyword_init: true
-    ) do
-      # @option args [String] :scheme_id
-      # @option args [Hash] :properties ({})
-      def initialize(*args)
-        super
-        self.properties ||= {}
+    class AuthScheme
+      # @param [String] :scheme_id
+      # @param [Hash] :properties ({})
+      def initialize(scheme_id:, properties: {})
+        @scheme_id = scheme_id
+        @properties = properties
       end
+
+      # The identifier of the authentication scheme.
+      # @return [String]
+      attr_accessor :scheme_id
+
+      # Additional properties of the authentication scheme.
+      # @return [Hash]
+      attr_accessor :properties
     end
 
     # An Endpoint resolved by an EndpointProvider
-    # @!attribute uri
-    #   The URI of the endpoint.
-    #   @return [String]
-    # @!attribute auth_schemes
-    #   The authentication schemes supported by the endpoint.
-    #   @return [Array<AuthScheme>]
-    # @!attribute headers
-    #   The headers to include in requests to the endpoint.
-    #   @return [Hash]
-    Endpoint = Struct.new(
-      :uri,
-      :auth_schemes,
-      :headers,
-      keyword_init: true
-    ) do
-      # @option args [String] :uri
-      # @option args [Array<AuthScheme>] :auth_schemes ([])
-      # @option args [Hash] :headers ({})
-      def initialize(*args)
-        super
-        self.auth_schemes ||= []
-        self.headers ||= {}
+    class Endpoint
+      # @param [String] :uri
+      # @param [Array<AuthScheme>] :auth_schemes ([])
+      # @param [Hash] :headers ({})
+      def initialize(uri:, auth_schemes: [], headers: {})
+        @uri = uri
+        @auth_schemes = auth_schemes
+        @headers = headers
       end
+
+      # The URI of the endpoint.
+      # @return [String]
+      attr_accessor :uri
+
+      # The authentication schemes supported by the endpoint.
+      # @return [Array<AuthScheme>]
+      attr_accessor :auth_schemes
+
+      # The headers to include in requests to the endpoint.
+      # @return [Hash]
+      attr_accessor :headers
     end
 
     # Evaluates whether the input string is a compliant RFC 1123 host segment.

--- a/hearth/lib/hearth/http/client.rb
+++ b/hearth/lib/hearth/http/client.rb
@@ -10,7 +10,7 @@ module Hearth
     # An HTTP client that uses Net::HTTP to send requests.
     class Client
       # @api private
-      OPTIONS = {
+      MEMBERS = {
         logger: nil,
         debug_output: nil,
         proxy: nil,
@@ -84,16 +84,16 @@ module Hearth
       #   optionally other keyword args similar to Addrinfo.getaddrinfo's
       #   positional parameters.
       def initialize(options = {})
-        unknown = options.keys - OPTIONS.keys
+        unknown = options.keys - MEMBERS.keys
         raise ArgumentError, "Unknown options: #{unknown}" unless unknown.empty?
 
-        OPTIONS.each_pair do |opt_name, default_value|
+        MEMBERS.each_pair do |opt_name, default_value|
           value = options.key?(opt_name) ? options[opt_name] : default_value
           instance_variable_set("@#{opt_name}", value)
         end
       end
 
-      OPTIONS.each_key do |attr_name|
+      MEMBERS.each_key do |attr_name|
         attr_reader(attr_name)
       end
 
@@ -254,7 +254,7 @@ module Hearth
       # Config options for the HTTP client used for connection pooling
       # @return [Hash]
       def pool_config
-        OPTIONS.each_key.with_object({}) do |option_name, hash|
+        MEMBERS.each_key.with_object({}) do |option_name, hash|
           hash[option_name] = instance_variable_get("@#{option_name}")
         end
       end

--- a/hearth/lib/hearth/middleware/auth.rb
+++ b/hearth/lib/hearth/middleware/auth.rb
@@ -44,14 +44,20 @@ module Hearth
 
       private
 
-      ResolvedAuth = Struct.new(
-        :scheme_id,
-        :signer,
-        :signer_properties,
-        :identity,
-        :identity_properties,
-        keyword_init: true
-      )
+      # @api private
+      class ResolvedAuth
+        def initialize(scheme_id:, signer:, signer_properties:,
+                       identity:, identity_properties:)
+          @scheme_id = scheme_id
+          @signer = signer
+          @signer_properties = signer_properties
+          @identity = identity
+          @identity_properties = identity_properties
+        end
+
+        attr_accessor :scheme_id, :signer, :signer_properties,
+                      :identity, :identity_properties
+      end
 
       def resolve_auth(auth_options)
         failures = []

--- a/hearth/lib/hearth/retry.rb
+++ b/hearth/lib/hearth/retry.rb
@@ -10,20 +10,19 @@ require_relative 'retry/standard'
 module Hearth
   module Retry
     # Represents a token that can be used to retry an operation.
-    # @!attribute retry_count
-    #   The number of times the operation has been retried.
-    #   @return [Integer]
-    # @!attribute retry_delay
-    #   The delay before the next retry.
-    #   @return [Numeric]
-    Token = Struct.new(:retry_count, :retry_delay, keyword_init: true) do
-      # @option args [Integer] :retry_count (0)
-      # @option args [Numeric] :retry_delay (0)
-      def initialize(*args)
-        super
-        self.retry_count ||= 0
-        self.retry_delay ||= 0
+    class Token
+      def initialize(retry_count: 0, retry_delay: 0)
+        @retry_count = retry_count
+        @retry_delay = retry_delay
       end
+
+      # The number of times the operation has been retried.
+      # @return [Integer]
+      attr_accessor :retry_count
+
+      # The delay before the next retry.
+      # @return [Numeric]
+      attr_accessor :retry_delay
     end
   end
 end

--- a/hearth/lib/hearth/structure.rb
+++ b/hearth/lib/hearth/structure.rb
@@ -23,7 +23,7 @@ module Hearth
     # Deeply converts the Struct into a hash. Structure members that
     # are `nil` are omitted from the resultant hash.
     #
-    # @return [Hash, Structure, Object]
+    # @return [Hash, Structure]
     def to_h(obj = self)
       case obj
       when Union

--- a/hearth/lib/hearth/validator.rb
+++ b/hearth/lib/hearth/validator.rb
@@ -59,12 +59,12 @@ module Hearth
     end
 
     # Validate unknown parameters are not present for a given Type.
-    # @param type [Structure] The Type to validate against.
+    # @param klass [Structure, Configuration] The class to validate against.
     # @param params [Hash] The parameters to validate.
     # @param context [String] The context of the value being validated.
     # @raise [ArgumentError] Raises when unknown parameters are present.
-    def self.validate_unknown!(type, params, context:)
-      unknown = params.keys - type.class::MEMBERS
+    def self.validate_unknown!(klass, params, context:)
+      unknown = params.keys - klass.class::MEMBERS
       return if unknown.empty?
 
       unknown = unknown.map { |key| "#{context}[:#{key}]" }

--- a/hearth/sig/lib/hearth/configuration.rbs
+++ b/hearth/sig/lib/hearth/configuration.rbs
@@ -4,6 +4,9 @@ module Hearth
 
     attr_reader options: Hash[Symbol, untyped]
 
+    def to_h: (self) -> (Hash[Symbol, untyped] | self)
+    alias to_hash to_h
+
     def merge: (Hash[Symbol, untyped] configuration) -> ServiceConfig
   end
 end

--- a/hearth/sig/lib/hearth/dns/host_address.rbs
+++ b/hearth/sig/lib/hearth/dns/host_address.rbs
@@ -1,11 +1,13 @@
 module Hearth
   module DNS
-    class HostAddress < Struct[untyped]
-      attr_reader address_type: Symbol
+    class HostAddress
+      def initialize: (address_type: Symbol, address: String, hostname: String) -> void
 
-      attr_reader address: String
+      attr_accessor address_type: Symbol
 
-      attr_reader hostname: String
+      attr_accessor address: String
+
+      attr_accessor hostname: String
     end
   end
 end

--- a/hearth/sig/lib/hearth/endpoint_rules.rbs
+++ b/hearth/sig/lib/hearth/endpoint_rules.rbs
@@ -1,12 +1,16 @@
 module Hearth
   module EndpointRules
-    class AuthScheme < Struct[untyped]
+    class AuthScheme
+      def initialize: (scheme_id: String, ?properties: ::Hash[String, untyped]) -> void
+
       attr_accessor scheme_id: String
 
       attr_accessor properties: Hash[String, untyped]
     end
 
-    class Endpoint < Struct[untyped]
+    class Endpoint
+      def initialize: (uri: String, ?auth_schemes: Array[AuthScheme], ?headers: Hash[String, String | Array[String]]) -> void
+
       attr_accessor uri: String
 
       attr_accessor auth_schemes: Array[AuthScheme]

--- a/hearth/sig/lib/hearth/retry.rbs
+++ b/hearth/sig/lib/hearth/retry.rbs
@@ -1,6 +1,8 @@
 module Hearth
   module Retry
-    class Token < Struct[untyped]
+    class Token
+      def initialize: (?retry_count: Integer, ?retry_delay: Numeric) -> void
+
       attr_accessor retry_count (): Integer
 
       attr_accessor retry_delay (): Numeric

--- a/hearth/sig/lib/hearth/structure.rbs
+++ b/hearth/sig/lib/hearth/structure.rbs
@@ -1,6 +1,6 @@
 module Hearth
   module Structure
-    def to_h: (self) -> (Hash[Symbol, untyped] | self)
+    def to_h: (self) -> Hash[Symbol, untyped]
     alias to_hash to_h
   end
 end

--- a/hearth/spec/hearth/cbor/cbor_spec.rb
+++ b/hearth/spec/hearth/cbor/cbor_spec.rb
@@ -22,7 +22,7 @@ module Hearth
           end
         when 'tag'
           value = expected_value(expect['tag']['value'])
-          CBOR::Tagged.new(expect['tag']['id'], value)
+          CBOR::Tagged.new(tag: expect['tag']['id'], value: value)
         when 'bool' then expect['bool']
         when 'null' then nil
         when 'undefined' then :undefined
@@ -34,16 +34,20 @@ module Hearth
       end
 
       def assert(actual, expected)
-        if expected.is_a?(Float) && expected.nan?
-          expect(actual.nan?).to be true
-        elsif expected.is_a?(Array)
+        case expected
+        when Array
           expected.each_with_index do |item, i|
             assert(actual[i], item)
           end
-        elsif expected.is_a?(Hash)
+        when Hash
           expected.each do |key, value|
             assert(actual[key], value)
           end
+        when Float
+          expect(actual.nan?).to be true if expected.nan?
+        when CBOR::Tagged
+          expect(actual.tag).to eq(expected.tag)
+          expect(actual.value).to eq(expected.value)
         else
           expect(actual).to eq(expected)
         end

--- a/hearth/spec/hearth/cbor/encoder_spec.rb
+++ b/hearth/spec/hearth/cbor/encoder_spec.rb
@@ -59,7 +59,7 @@ module Hearth
         end
 
         it 'encodes Tagged items' do
-          expect(cbor64_encode(Tagged.new(0, 0))).to eq('wAA=')
+          expect(cbor64_encode(Tagged.new(tag: 0, value: 0))).to eq('wAA=')
         end
 
         it 'encodes arrays' do

--- a/hearth/spec/hearth/config/resolver_spec.rb
+++ b/hearth/spec/hearth/config/resolver_spec.rb
@@ -2,23 +2,24 @@
 
 module Hearth
   module Config
+    class TestResolverConfig
+      MEMBERS = %i[
+        option1
+        option2
+      ].freeze
+
+      attr_accessor(*MEMBERS)
+    end
+
     describe Resolver do
       subject { Resolver }
-
-      let(:config_class) do
-        Struct.new(
-          :option1,
-          :option2,
-          keyword_init: true
-        )
-      end
 
       it 'cannot be initialized' do
         expect { subject.new }.to raise_error(NoMethodError)
       end
 
       describe '.resolve' do
-        let(:config) { config_class.new }
+        let(:config) { TestResolverConfig.new }
 
         it 'creates the config with provided options' do
           defaults = { option1: ['should not be used'] }

--- a/hearth/spec/hearth/configuration_spec.rb
+++ b/hearth/spec/hearth/configuration_spec.rb
@@ -1,62 +1,92 @@
 # frozen_string_literal: true
 
 module Hearth
-  describe Configuration do
-    let(:config_class) do
-      Struct.new(:simple_option, keyword_init: true) do
-        include Hearth::Configuration
+  class TestConfiguration
+    MEMBERS = %i[
+      simple_option
+      complex_option
+    ].freeze
 
-        def validate!
-          Hearth::Validator.validate_types!(
-            simple_option, String, context: 'config[:simple_option]'
-          )
-        end
+    include Hearth::Configuration
 
-        private
+    attr_accessor(*MEMBERS)
 
-        def _defaults
-          { simple_option: ['default'] }
-        end
-      end
+    def validate!
+      Hearth::Validator.validate_types!(
+        simple_option, String,
+        context: 'config[:simple_option]'
+      )
+      Hearth::Validator.validate_types!(
+        complex_option, Object,
+        context: 'config[:complex_option]'
+      )
     end
 
+    private
+
+    def _defaults
+      {
+        simple_option: ['default'],
+        complex_option: [Object.new]
+      }.freeze
+    end
+  end
+
+  describe Configuration do
     describe '#initialize' do
       it 'uses the config resolver' do
         options = { simple_option: 'test' }
         expect(Hearth::Config::Resolver).to receive(:resolve)
           .with(
-            an_instance_of(config_class),
+            an_instance_of(TestConfiguration),
             options,
-            { simple_option: ['default'] }
+            {
+              simple_option: ['default'],
+              complex_option: [an_instance_of(Object)]
+            }
           ).and_call_original
 
-        config = config_class.new(**options)
+        config = TestConfiguration.new(**options)
         expect(config.simple_option).to eq('test')
       end
 
       it 'resolves correctly when not passed any options' do
         expect(Hearth::Config::Resolver).to receive(:resolve)
           .with(
-            an_instance_of(config_class),
+            an_instance_of(TestConfiguration),
             {},
-            { simple_option: ['default'] }
+            {
+              simple_option: ['default'],
+              complex_option: [an_instance_of(Object)]
+            }
           ).and_call_original
 
-        config = config_class.new
+        config = TestConfiguration.new
         expect(config.simple_option).to eq('default')
       end
 
       it 'raises on unknown options' do
         expect do
-          config_class.new(unknown_option: 'test')
-        end.to raise_error(ArgumentError, /unknown_option/)
+          TestConfiguration.new(unknown_option: 'test')
+        end.to raise_error(ArgumentError, /config\[:unknown_option\]/)
+      end
+    end
+
+    describe '#to_h' do
+      it 'returns the configuration as a hash' do
+        object = Object.new
+        config = TestConfiguration.new(
+          simple_option: 'test',
+          complex_option: object
+        )
+        expect(config.to_h).to eq(simple_option: 'test', complex_option: object)
       end
     end
 
     describe '#merge' do
       it 'merges the configuration' do
-        config = config_class.new(simple_option: 'test')
-        merged = config.merge(config_class.new(simple_option: 'test2'))
+        config = TestConfiguration.new(simple_option: 'test')
+        merged = config.merge(TestConfiguration.new(simple_option: 'test2'))
         expect(merged.simple_option).to eq('test2')
       end
     end

--- a/hearth/spec/hearth/context_spec.rb
+++ b/hearth/spec/hearth/context_spec.rb
@@ -48,7 +48,13 @@ module Hearth
 
     describe '#auth' do
       it 'allows for auth to be set' do
-        resolved_auth = Hearth::Middleware::Auth::ResolvedAuth.new
+        resolved_auth = Hearth::Middleware::Auth::ResolvedAuth.new(
+          scheme_id: double,
+          signer: double,
+          signer_properties: double,
+          identity: double,
+          identity_properties: double
+        )
         subject.auth = resolved_auth
         expect(subject.auth).to eq(resolved_auth)
       end

--- a/hearth/spec/hearth/dns/host_address_spec.rb
+++ b/hearth/spec/hearth/dns/host_address_spec.rb
@@ -3,12 +3,34 @@
 module Hearth
   module DNS
     describe HostAddress do
-      it 'can be initialized' do
+      let(:address_type) { :A }
+      let(:address) { '123.123.123.123' }
+      let(:hostname) { 'example.com' }
+
+      subject do
         HostAddress.new(
-          address_type: :A,
-          address: '123.123.123.123',
-          hostname: 'example.com'
+          address_type: address_type,
+          address: address,
+          hostname: hostname
         )
+      end
+
+      describe '#address_type' do
+        it 'returns the address type' do
+          expect(subject.address_type).to eq(address_type)
+        end
+      end
+
+      describe '#address' do
+        it 'returns the address' do
+          expect(subject.address).to eq(address)
+        end
+      end
+
+      describe '#hostname' do
+        it 'returns the hostname' do
+          expect(subject.hostname).to eq(hostname)
+        end
       end
     end
   end

--- a/hearth/spec/hearth/http/error_parser_spec.rb
+++ b/hearth/spec/hearth/http/error_parser_spec.rb
@@ -22,13 +22,13 @@ module Hearth
 
       class ApiServerError < ApiError; end
 
-      class TestModeledError < ApiClientError; end
+      class ModeledError < ApiClientError; end
     end
 
     describe ErrorParser do
       let(:error_module) { TestErrors }
       let(:success_status) { 200 }
-      let(:errors) { [TestErrors::TestModeledError] }
+      let(:errors) { [TestErrors::ModeledError] }
 
       let(:resp_status) { 200 }
       let(:fields) { Fields.new }
@@ -98,7 +98,7 @@ module Hearth
         context 'error code on response' do
           before do
             expect(TestErrors).to receive(:error_code)
-              .with(http_resp).and_return('TestModeledError')
+              .with(http_resp).and_return('ModeledError')
           end
 
           context 'error response: 2XX with error code' do
@@ -106,7 +106,7 @@ module Hearth
 
             it 'returns the modeled error' do
               error = subject.parse(http_resp, metadata)
-              expect(error).to be_a(TestErrors::TestModeledError)
+              expect(error).to be_a(TestErrors::ModeledError)
             end
 
             context 'Modeled error not in errors' do
@@ -124,7 +124,7 @@ module Hearth
 
             it 'returns the modeled error' do
               error = subject.parse(http_resp, metadata)
-              expect(error).to be_a(TestErrors::TestModeledError)
+              expect(error).to be_a(TestErrors::ModeledError)
             end
           end
         end

--- a/hearth/spec/hearth/middleware/endpoint_spec.rb
+++ b/hearth/spec/hearth/middleware/endpoint_spec.rb
@@ -2,7 +2,7 @@
 
 module Hearth
   module Middleware
-    class EndpointInput
+    class TestEndpointInput
       include Hearth::Structure
 
       MEMBERS = %i[foo].freeze
@@ -12,7 +12,7 @@ module Hearth
 
     describe Endpoint do
       let(:app) { double('app', call: output) }
-      let(:input) { EndpointInput.new }
+      let(:input) { TestEndpointInput.new }
       let(:output) { double('output') }
       let(:endpoint_resolver) { double }
       let(:param_builder) { double }

--- a/hearth/spec/hearth/middleware/endpoint_spec.rb
+++ b/hearth/spec/hearth/middleware/endpoint_spec.rb
@@ -2,10 +2,17 @@
 
 module Hearth
   module Middleware
+    class EndpointInput
+      include Hearth::Structure
+
+      MEMBERS = %i[foo].freeze
+
+      attr_accessor(*MEMBERS)
+    end
+
     describe Endpoint do
       let(:app) { double('app', call: output) }
-      let(:struct) { Struct.new(:foo, keyword_init: true) }
-      let(:input) { struct.new }
+      let(:input) { EndpointInput.new }
       let(:output) { double('output') }
       let(:endpoint_resolver) { double }
       let(:param_builder) { double }

--- a/hearth/spec/hearth/middleware/host_prefix_spec.rb
+++ b/hearth/spec/hearth/middleware/host_prefix_spec.rb
@@ -2,7 +2,7 @@
 
 module Hearth
   module Middleware
-    class HostPrefixInput
+    class TestHostPrefixInput
       include Hearth::Structure
 
       MEMBERS = %i[foo].freeze
@@ -12,7 +12,7 @@ module Hearth
 
     describe HostPrefix do
       let(:app) { double('app', call: output) }
-      let(:input) { HostPrefixInput.new }
+      let(:input) { TestHostPrefixInput.new }
       let(:output) { double('output') }
       let(:host_prefix) { 'foo.' }
 
@@ -49,7 +49,7 @@ module Hearth
 
           context 'host prefix has labels' do
             let(:host_prefix) { '{foo}.' }
-            let(:input) { HostPrefixInput.new(foo: 'bar') }
+            let(:input) { TestHostPrefixInput.new(foo: 'bar') }
 
             it 'populates the label with input' do
               expect(app).to receive(:call).with(input, context)
@@ -60,7 +60,7 @@ module Hearth
             end
 
             context 'input does not have the label' do
-              let(:input) { HostPrefixInput.new }
+              let(:input) { TestHostPrefixInput.new }
 
               it 'raises an ArgumentError' do
                 expect do
@@ -70,7 +70,7 @@ module Hearth
             end
 
             context 'input has an empty label' do
-              let(:input) { HostPrefixInput.new(foo: '') }
+              let(:input) { TestHostPrefixInput.new(foo: '') }
 
               it 'raises an ArgumentError' do
                 expect do

--- a/hearth/spec/hearth/middleware/host_prefix_spec.rb
+++ b/hearth/spec/hearth/middleware/host_prefix_spec.rb
@@ -2,10 +2,17 @@
 
 module Hearth
   module Middleware
+    class HostPrefixInput
+      include Hearth::Structure
+
+      MEMBERS = %i[foo].freeze
+
+      attr_accessor(*MEMBERS)
+    end
+
     describe HostPrefix do
       let(:app) { double('app', call: output) }
-      let(:struct) { Struct.new(:foo, keyword_init: true) }
-      let(:input) { struct.new }
+      let(:input) { HostPrefixInput.new }
       let(:output) { double('output') }
       let(:host_prefix) { 'foo.' }
 
@@ -42,7 +49,7 @@ module Hearth
 
           context 'host prefix has labels' do
             let(:host_prefix) { '{foo}.' }
-            let(:input) { struct.new(foo: 'bar') }
+            let(:input) { HostPrefixInput.new(foo: 'bar') }
 
             it 'populates the label with input' do
               expect(app).to receive(:call).with(input, context)
@@ -53,7 +60,7 @@ module Hearth
             end
 
             context 'input does not have the label' do
-              let(:input) { struct.new }
+              let(:input) { HostPrefixInput.new }
 
               it 'raises an ArgumentError' do
                 expect do
@@ -63,7 +70,7 @@ module Hearth
             end
 
             context 'input has an empty label' do
-              let(:input) { struct.new(foo: '') }
+              let(:input) { HostPrefixInput.new(foo: '') }
 
               it 'raises an ArgumentError' do
                 expect do

--- a/hearth/spec/hearth/middleware/send_spec.rb
+++ b/hearth/spec/hearth/middleware/send_spec.rb
@@ -3,12 +3,20 @@
 module Hearth
   module Middleware
     module Types
-      StubData = ::Struct.new(:member, keyword_init: true) do
+      class StubData
         include Hearth::Structure
+
+        MEMBERS = %i[member].freeze
+
+        attr_accessor(*MEMBERS)
       end
 
-      StubErrorData = ::Struct.new(:message, keyword_init: true) do
+      class StubErrorData
         include Hearth::Structure
+
+        MEMBERS = %i[message].freeze
+
+        attr_accessor(*MEMBERS)
       end
     end
 

--- a/hearth/spec/hearth/structure_spec.rb
+++ b/hearth/spec/hearth/structure_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Hearth
-  class MyStructure
+  class TestStructure
     include Hearth::Structure
 
     MEMBERS = %i[
@@ -27,15 +27,15 @@ module Hearth
 
   describe Structure do
     subject do
-      MyStructure.new(
-        struct_value: MyStructure.new(value: 'foo'),
+      TestStructure.new(
+        struct_value: TestStructure.new(value: 'foo'),
         array_value: [
-          MyStructure.new(value: 'foo'),
-          MyStructure.new(value: 'bar')
+          TestStructure.new(value: 'foo'),
+          TestStructure.new(value: 'bar')
         ],
-        hash_value: { key: MyStructure.new(value: 'value') },
+        hash_value: { key: TestStructure.new(value: 'value') },
         value: 'value',
-        union_value: MyUnion::StringValue.new('union'),
+        union_value: TestUnion::StringValue.new('union'),
         some_object: Object.new
       )
     end

--- a/hearth/spec/hearth/stubbing/client_stubs_spec.rb
+++ b/hearth/spec/hearth/stubbing/client_stubs_spec.rb
@@ -1,15 +1,31 @@
 # frozen_string_literal: true
 
 module Hearth
-  module ClientStubTest
-    Config = Struct.new(:stub_responses, :stubs, keyword_init: true)
+  module TestClientStubs
+    class Config
+      MEMBERS = %i[
+        stub_responses
+        stubs
+      ].freeze
+
+      include Hearth::Configuration
+
+      attr_accessor(*MEMBERS)
+
+      private
+
+      def _defaults
+        {
+          stubs: [Hearth::Stubs.new]
+        }.freeze
+      end
+    end
 
     class Client
       include ClientStubs
 
       def initialize(config = Config.new)
         @config = config
-        @config.stubs = Hearth::Stubs.new
       end
 
       attr_accessor :config
@@ -17,8 +33,11 @@ module Hearth
   end
 
   describe ClientStubs do
-    let(:config) { ClientStubTest::Config.new(stub_responses: stub_responses) }
-    subject { ClientStubTest::Client.new(config) }
+    let(:config) do
+      TestClientStubs::Config.new(stub_responses: stub_responses)
+    end
+
+    subject { TestClientStubs::Client.new(config) }
 
     describe '#stub_responses' do
       context 'stub_responses is true' do

--- a/hearth/spec/hearth/union_spec.rb
+++ b/hearth/spec/hearth/union_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Hearth
-  class MyUnion < Hearth::Union
-    class StringValue < MyUnion
+  class TestUnion < Hearth::Union
+    class StringValue < TestUnion
       def to_h
         { string_value: super(__getobj__) }
       end
@@ -10,7 +10,7 @@ module Hearth
   end
 
   describe Union do
-    subject { MyUnion::StringValue.new('union') }
+    subject { TestUnion::StringValue.new('union') }
 
     it 'uses simple delegator and structure' do
       expect(subject).to be_a(SimpleDelegator)

--- a/hearth/spec/hearth/validator_spec.rb
+++ b/hearth/spec/hearth/validator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Hearth
-  class MyType
+  class TestValidatorInput
     include Hearth::Structure
 
     MEMBERS = %i[foo].freeze
@@ -10,7 +10,7 @@ module Hearth
   end
 
   describe Validator do
-    let(:input) { MyType.new(params) }
+    let(:input) { TestValidatorInput.new(params) }
     let(:context) { 'input' }
 
     describe '.validate_range!' do
@@ -180,7 +180,7 @@ module Hearth
     end
 
     describe '.validate_unknown!' do
-      let(:input) { MyType.new }
+      let(:input) { TestValidatorInput.new }
 
       context 'all members are known' do
         let(:params) { { foo: 'bar' } }

--- a/hearth/spec/hearth/waiters/poller_spec.rb
+++ b/hearth/spec/hearth/waiters/poller_spec.rb
@@ -2,7 +2,7 @@
 
 module Hearth
   module Waiters
-    class WaiterInput
+    class TestWaiterInput
       include Hearth::Structure
 
       MEMBERS = %i[string boolean all_string any_string].freeze
@@ -21,7 +21,7 @@ module Hearth
       let(:client) { double('client') }
       let(:input_output_interceptor) { double('input_output_interceptor') }
       let(:input) do
-        WaiterInput.new(
+        TestWaiterInput.new(
           string: 'peccy',
           boolean: true,
           all_string: %w[foo foo],

--- a/hearth/spec/hearth/waiters/poller_spec.rb
+++ b/hearth/spec/hearth/waiters/poller_spec.rb
@@ -2,6 +2,14 @@
 
 module Hearth
   module Waiters
+    class WaiterInput
+      include Hearth::Structure
+
+      MEMBERS = %i[string boolean all_string any_string].freeze
+
+      attr_accessor(*MEMBERS)
+    end
+
     describe Poller do
       subject do
         Poller.new(
@@ -12,18 +20,8 @@ module Hearth
 
       let(:client) { double('client') }
       let(:input_output_interceptor) { double('input_output_interceptor') }
-
-      let(:test_operation_struct) do
-        Struct.new(
-          :string,
-          :boolean,
-          :all_string,
-          :any_string,
-          keyword_init: true
-        )
-      end
-      let(:struct) do
-        test_operation_struct.new(
+      let(:input) do
+        WaiterInput.new(
           string: 'peccy',
           boolean: true,
           all_string: %w[foo foo],
@@ -32,7 +30,7 @@ module Hearth
       end
 
       let(:interceptor_context) do
-        double('ictx', input: struct)
+        double('ictx', input: input)
       end
 
       let(:error) do
@@ -73,9 +71,9 @@ module Hearth
             it 'returns retry state with response' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:retry, struct]
+              expect(subject.call(client, {}, {})).to eq [:retry, input]
             end
           end
         end
@@ -90,9 +88,9 @@ module Hearth
           it 'can match success' do
             expect(client).to receive(:test_operation)
               .with({}, { interceptors: [input_output_interceptor] })
-              .and_return(struct)
+              .and_return(input)
 
-            expect(subject.call(client, {}, {})).to eq [:success, struct]
+            expect(subject.call(client, {}, {})).to eq [:success, input]
           end
         end
 
@@ -132,9 +130,9 @@ module Hearth
             it 'can match string equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
 
@@ -157,9 +155,9 @@ module Hearth
             it 'can match boolean equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
 
@@ -182,9 +180,9 @@ module Hearth
             it 'can match boolean equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
 
@@ -207,9 +205,9 @@ module Hearth
             it 'can match boolean equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
         end
@@ -234,9 +232,9 @@ module Hearth
             it 'can match string equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
 
@@ -259,9 +257,9 @@ module Hearth
             it 'can match boolean equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
 
@@ -284,9 +282,9 @@ module Hearth
             it 'can match boolean equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
 
@@ -309,9 +307,9 @@ module Hearth
             it 'can match boolean equals' do
               expect(client).to receive(:test_operation)
                 .with({}, { interceptors: [input_output_interceptor] })
-                .and_return(struct)
+                .and_return(input)
 
-              expect(subject.call(client, {}, {})).to eq [:success, struct]
+              expect(subject.call(client, {}, {})).to eq [:success, input]
             end
           end
         end
@@ -345,9 +343,9 @@ module Hearth
           it 'iterates all matchers' do
             expect(client).to receive(:test_operation)
               .with({}, { interceptors: [input_output_interceptor] })
-              .and_return(struct)
+              .and_return(input)
 
-            expect(subject.call(client, {}, {})).to eq [:success, struct]
+            expect(subject.call(client, {}, {})).to eq [:success, input]
           end
         end
       end

--- a/hearth/spec/hearth/waiters/waiter_spec.rb
+++ b/hearth/spec/hearth/waiters/waiter_spec.rb
@@ -26,6 +26,14 @@ module Hearth
       end
     end
 
+    class WaiterOutput
+      include Hearth::Structure
+
+      MEMBERS = %i[member].freeze
+
+      attr_accessor(*MEMBERS)
+    end
+
     describe Waiter do
       subject do
         Waiter.new(
@@ -38,9 +46,7 @@ module Hearth
 
       let(:poller) { double('poller') }
       let(:client) { double('client') }
-
-      let(:response_struct) { Struct.new(:member, keyword_init: true) }
-      let(:response) { response_struct.new(member: 'foo') }
+      let(:response) { WaiterOutput.new(member: 'foo') }
 
       let(:error) do
         Hearth::ApiError.new(

--- a/hearth/spec/hearth/waiters/waiter_spec.rb
+++ b/hearth/spec/hearth/waiters/waiter_spec.rb
@@ -26,7 +26,7 @@ module Hearth
       end
     end
 
-    class WaiterOutput
+    class TestWaiterOutput
       include Hearth::Structure
 
       MEMBERS = %i[member].freeze
@@ -46,7 +46,7 @@ module Hearth
 
       let(:poller) { double('poller') }
       let(:client) { double('client') }
-      let(:response) { WaiterOutput.new(member: 'foo') }
+      let(:response) { TestWaiterOutput.new(member: 'foo') }
 
       let(:error) do
         Hearth::ApiError.new(


### PR DESCRIPTION
Removes Struct from:
* Auth
* Endpoints
* Various Hearth internal structures
* Config

This is because RBS with Struct is not well supported.