### PR TITLE
refactor: drive JSON/CBOR serde off the data with a load-time wire-name map

### DIFF
--- a/gems/smithy-cbor/lib/smithy-cbor/builder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/builder.rb
@@ -53,10 +53,19 @@ module Smithy
 
       def structure(shape, values)
         return if values.nil?
+        # Mirrors smithy-json's guard for the same reason (see that builder's
+        # `structure` method): unreachable today since `build` already
+        # short-circuits `Prelude::Unit` above, but keeps both builders'
+        # fallback behavior identical if that ever changes. Flagged for
+        # review, not verified against a real non-hash input reaching here.
+        return {} unless values.respond_to?(:each_pair)
 
-        shape.target.members.each_with_object({}) do |(member_name, member_shape), data|
-          value = values[member_name]
+        members = shape.target.members
+        values.each_pair.with_object({}) do |(member_name, value), data|
           next if value.nil?
+
+          member_shape = members[member_name]
+          next unless member_shape
 
           data[member_shape.location_name] = build_shape(member_shape, value)
         end

--- a/gems/smithy-cbor/lib/smithy-cbor/builder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/builder.rb
@@ -53,12 +53,6 @@ module Smithy
 
       def structure(shape, values)
         return if values.nil?
-        # Mirrors smithy-json's guard for the same reason (see that builder's
-        # `structure` method): unreachable today since `build` already
-        # short-circuits `Prelude::Unit` above, but keeps both builders'
-        # fallback behavior identical if that ever changes. Flagged for
-        # review, not verified against a real non-hash input reaching here.
-        return {} unless values.respond_to?(:each_pair)
 
         members = shape.target.members
         values.each_pair.with_object({}) do |(member_name, value), data|

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -54,9 +54,13 @@ module Smithy
 
       def structure(shape, values, result = nil)
         result = shape.target.type.new if result.nil?
-        shape.target.members.each do |member_name, member_shape|
-          value = values[member_shape.location_name]
-          result[member_name] = parse_shape(member_shape, value) unless value.nil?
+        values.each do |wire_name, value|
+          next if value.nil?
+
+          member_name, member_shape = shape.target.member_by_wire_name(wire_name)
+          next unless member_shape
+
+          result[member_name] = parse_shape(member_shape, value)
         end
         result
       end

--- a/gems/smithy-cbor/spec/smithy-cbor/builder_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/builder_spec.rb
@@ -73,6 +73,16 @@ module Smithy
           bytes = subject.build(structure_shape, data.merge(structure: data))
           expect(Cbor.decode(bytes)).to eq(expected.merge('structure' => expected))
         end
+
+        it 'builds only the members present on a sparse input, iterating values not declared members' do
+          bytes = subject.build(structure_shape, { string: 'string', integer: 1 })
+          expect(Cbor.decode(bytes)).to eq('string' => 'string', 'integer' => 1)
+        end
+
+        it 'skips keys in the input that are not declared members of the shape' do
+          bytes = subject.build(structure_shape, { string: 'string', not_a_real_member: 'ignored' })
+          expect(Cbor.decode(bytes)).to eq('string' => 'string')
+        end
       end
 
       context 'unions' do

--- a/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
@@ -73,6 +73,18 @@ module Smithy
           bytes = Cbor.encode(data)
           expect(subject.parse(structure_shape, bytes).to_h).to eq(expected)
         end
+
+        it 'ignores wire keys that are not members' do
+          data = { 'string' => 'string', 'notAMember' => 'ignored' }
+          bytes = Cbor.encode(data)
+          expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
+        end
+
+        it 'skips members whose wire value is nil' do
+          data = { 'string' => nil }
+          bytes = Cbor.encode(data)
+          expect(subject.parse(structure_shape, bytes).to_h).to eq({})
+        end
       end
 
       context 'unions' do

--- a/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
@@ -79,7 +79,6 @@ module Smithy
           bytes = Cbor.encode(data)
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
-
       end
 
       context 'unions' do

--- a/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
@@ -80,11 +80,6 @@ module Smithy
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
 
-        it 'skips members whose wire value is nil' do
-          data = { 'string' => nil }
-          bytes = Cbor.encode(data)
-          expect(subject.parse(structure_shape, bytes).to_h).to eq({})
-        end
       end
 
       context 'unions' do

--- a/gems/smithy-json/lib/smithy-json/builder.rb
+++ b/gems/smithy-json/lib/smithy-json/builder.rb
@@ -65,10 +65,16 @@ module Smithy
 
       def structure(shape, values)
         return if values.nil?
+        return {} unless values.respond_to?(:each_pair)
 
-        shape.target.members.each_with_object({}) do |(member_name, member_shape), data|
-          value = values[member_name]
-          data[location_name(member_shape)] = build_shape(member_shape, value) unless value.nil?
+        members = shape.target.members
+        values.each_pair.with_object({}) do |(member_name, value), data|
+          next if value.nil?
+
+          member_shape = members[member_name]
+          next unless member_shape
+
+          data[location_name(member_shape)] = build_shape(member_shape, value)
         end
       end
 

--- a/gems/smithy-json/lib/smithy-json/builder.rb
+++ b/gems/smithy-json/lib/smithy-json/builder.rb
@@ -65,7 +65,6 @@ module Smithy
 
       def structure(shape, values)
         return if values.nil?
-        return {} unless values.respond_to?(:each_pair)
 
         members = shape.target.members
         values.each_pair.with_object({}) do |(member_name, value), data|

--- a/gems/smithy-json/lib/smithy-json/parser.rb
+++ b/gems/smithy-json/lib/smithy-json/parser.rb
@@ -68,9 +68,13 @@ module Smithy
         return if values.nil?
 
         result = shape.target.type.new if result.nil?
-        shape.target.members.each do |member_name, member_shape|
-          value = values[location_name(member_shape)]
-          result[member_name] = parse_shape(member_shape, value) unless value.nil?
+        values.each do |wire_name, value|
+          next if value.nil?
+
+          member_name, member_shape = shape.target.member_by_wire_name(wire_name)
+          next unless member_shape
+
+          result[member_name] = parse_shape(member_shape, value)
         end
         result
       end

--- a/gems/smithy-json/spec/smithy-json/builder_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/builder_spec.rb
@@ -9,8 +9,8 @@ module Smithy
       let(:sample_schema) { SchemaHelper.sample_schema(shapes: shapes) }
       let(:structure_shape) { sample_schema.const_get(:Structure) }
 
-      it 'returns an empty hash when given a unit shape' do
-        expect(subject.build(Schema::Shapes::Prelude::Unit, '')).to eq('{}')
+      it 'returns an empty JSON object for a unit shape' do
+        expect(subject.build(Schema::Shapes::Prelude::Unit, {})).to eq('{}')
       end
 
       context 'structures' do

--- a/gems/smithy-json/spec/smithy-json/builder_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/builder_spec.rb
@@ -86,6 +86,18 @@ module Smithy
           bytes = subject.build(structure_shape, data)
           expect(Json.load(bytes)).to eq('NewString' => 'string')
         end
+
+        it 'builds only the members present on a sparse input, iterating values not declared members' do
+          data = { string: 'string', integer: 1 }
+          bytes = subject.build(structure_shape, data)
+          expect(Json.load(bytes)).to eq('string' => 'string', 'integer' => 1)
+        end
+
+        it 'skips keys in the input that are not declared members of the shape' do
+          data = { string: 'string', not_a_real_member: 'ignored' }
+          bytes = subject.build(structure_shape, data)
+          expect(Json.load(bytes)).to eq('string' => 'string')
+        end
       end
 
       context 'unions' do

--- a/gems/smithy-json/spec/smithy-json/parser_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/parser_spec.rb
@@ -100,7 +100,6 @@ module Smithy
           bytes = Json.dump(data)
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
-
       end
 
       context 'unions' do

--- a/gems/smithy-json/spec/smithy-json/parser_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/parser_spec.rb
@@ -101,11 +101,6 @@ module Smithy
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
 
-        it 'skips members whose wire value is nil' do
-          data = { 'string' => nil }
-          bytes = Json.dump(data)
-          expect(subject.parse(structure_shape, bytes).to_h).to eq({})
-        end
       end
 
       context 'unions' do

--- a/gems/smithy-json/spec/smithy-json/parser_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/parser_spec.rb
@@ -84,6 +84,28 @@ module Smithy
           bytes = Json.dump(data)
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
+
+        it 'resolves members keyed by jsonName even without the json_name option' do
+          shapes['smithy.ruby.tests#Structure']['members']['string'] = {
+            'target' => 'smithy.api#String',
+            'traits' => { 'smithy.api#jsonName' => 'NewString' }
+          }
+          data = { 'NewString' => 'string' }
+          bytes = Json.dump(data)
+          expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
+        end
+
+        it 'ignores wire keys that are not members' do
+          data = { 'string' => 'string', 'notAMember' => 'ignored' }
+          bytes = Json.dump(data)
+          expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
+        end
+
+        it 'skips members whose wire value is nil' do
+          data = { 'string' => nil }
+          bytes = Json.dump(data)
+          expect(subject.parse(structure_shape, bytes).to_h).to eq({})
+        end
       end
 
       context 'unions' do

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -235,7 +235,7 @@ module Smithy
         def initialize(options = {})
           super
           @members = {}
-          @members_by_wire_name = {}
+          @members_by_wire_name = {}  # Temporary wire-name map. Removed by schema extensions.
         end
 
         # @return [Hash<Symbol, MemberShape>]
@@ -247,6 +247,7 @@ module Smithy
         # @return [MemberShape]
         def add_member(name, member_shape)
           @members[name] = member_shape
+          # Temporary wire-name map. Removed by schema extensions.
           @members_by_wire_name[member_shape.location_name] = [name, member_shape]
           json_name = member_shape.traits['smithy.api#jsonName']
           if json_name && json_name != member_shape.location_name
@@ -267,10 +268,7 @@ module Smithy
           @members[name]
         end
 
-        # Resolves a member from its on-the-wire name. Members are registered
-        # under both their +location_name+ and their +jsonName+ (when present),
-        # so a response keyed by either flavor resolves without the shape
-        # carrying a protocol-specific winner. Built once at load time.
+        # Temporary wire-name map. Removed by schema extensions.
         # @param [String] wire_name
         # @return [[Symbol, MemberShape], nil] +[member_name, member_shape]+ or nil
         def member_by_wire_name(wire_name)

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -247,14 +247,16 @@ module Smithy
         # @return [MemberShape]
         def add_member(name, member_shape)
           @members[name] = member_shape
-          # TODO (schema-caching): temporary reverse map for data-driven JSON/CBOR
+          # TODO: (schema-caching): temporary reverse map for data-driven JSON/CBOR
           # deserialization, mirroring V3's members_by_location_name (last write
           # wins). Registered under location_name and jsonName; remove once the
           # schema-caching rework provides per-protocol wire-name resolution. XML
           # resolves xmlName through its own per-frame parser path, not this map.
           @members_by_wire_name[member_shape.location_name] = [name, member_shape]
           json_name = member_shape.traits['smithy.api#jsonName']
-          @members_by_wire_name[json_name] = [name, member_shape] if json_name && json_name != member_shape.location_name
+          if json_name && json_name != member_shape.location_name
+            @members_by_wire_name[json_name] = [name, member_shape]
+          end
           member_shape
         end
 

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -235,6 +235,7 @@ module Smithy
         def initialize(options = {})
           super
           @members = {}
+          @members_by_wire_name = {}
         end
 
         # @return [Hash<Symbol, MemberShape>]
@@ -246,6 +247,10 @@ module Smithy
         # @return [MemberShape]
         def add_member(name, member_shape)
           @members[name] = member_shape
+          register_wire_name(member_shape.location_name, name, member_shape)
+          json_name = member_shape.traits['smithy.api#jsonName']
+          register_wire_name(json_name, name, member_shape) if json_name && json_name != member_shape.location_name
+          member_shape
         end
 
         # @param [Symbol] name
@@ -258,6 +263,31 @@ module Smithy
         # @return [MemberShape, nil]
         def member(name)
           @members[name]
+        end
+
+        # Resolves a member from its on-the-wire name. Members are registered
+        # under both their +location_name+ and their +jsonName+ (when present),
+        # so a response keyed by either flavor resolves without the shape
+        # carrying a protocol-specific winner. Built once at load time.
+        # @param [String] wire_name
+        # @return [[Symbol, MemberShape], nil] +[member_name, member_shape]+ or nil
+        def member_by_wire_name(wire_name)
+          @members_by_wire_name[wire_name]
+        end
+
+        private
+
+        def register_wire_name(wire_name, name, member_shape)
+          return if wire_name.nil?
+
+          existing = @members_by_wire_name[wire_name]
+          if existing && existing[0] != name
+            raise ArgumentError,
+                  "wire name collision on #{@id.inspect}: #{wire_name.inspect} " \
+                  "maps to both #{existing[0].inspect} and #{name.inspect}"
+          end
+
+          @members_by_wire_name[wire_name] = [name, member_shape]
         end
       end
 

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -247,11 +247,6 @@ module Smithy
         # @return [MemberShape]
         def add_member(name, member_shape)
           @members[name] = member_shape
-          # TODO: (schema-caching): temporary reverse map for data-driven JSON/CBOR
-          # deserialization, mirroring V3's members_by_location_name (last write
-          # wins). Registered under location_name and jsonName; remove once the
-          # schema-caching rework provides per-protocol wire-name resolution. XML
-          # resolves xmlName through its own per-frame parser path, not this map.
           @members_by_wire_name[member_shape.location_name] = [name, member_shape]
           json_name = member_shape.traits['smithy.api#jsonName']
           if json_name && json_name != member_shape.location_name

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -247,9 +247,14 @@ module Smithy
         # @return [MemberShape]
         def add_member(name, member_shape)
           @members[name] = member_shape
-          register_wire_name(member_shape.location_name, name, member_shape)
+          # TODO (schema-caching): temporary reverse map for data-driven JSON/CBOR
+          # deserialization, mirroring V3's members_by_location_name (last write
+          # wins). Registered under location_name and jsonName; remove once the
+          # schema-caching rework provides per-protocol wire-name resolution. XML
+          # resolves xmlName through its own per-frame parser path, not this map.
+          @members_by_wire_name[member_shape.location_name] = [name, member_shape]
           json_name = member_shape.traits['smithy.api#jsonName']
-          register_wire_name(json_name, name, member_shape) if json_name && json_name != member_shape.location_name
+          @members_by_wire_name[json_name] = [name, member_shape] if json_name && json_name != member_shape.location_name
           member_shape
         end
 
@@ -273,21 +278,6 @@ module Smithy
         # @return [[Symbol, MemberShape], nil] +[member_name, member_shape]+ or nil
         def member_by_wire_name(wire_name)
           @members_by_wire_name[wire_name]
-        end
-
-        private
-
-        def register_wire_name(wire_name, name, member_shape)
-          return if wire_name.nil?
-
-          existing = @members_by_wire_name[wire_name]
-          if existing && existing[0] != name
-            raise ArgumentError,
-                  "wire name collision on #{@id.inspect}: #{wire_name.inspect} " \
-                  "maps to both #{existing[0].inspect} and #{name.inspect}"
-          end
-
-          @members_by_wire_name[wire_name] = [name, member_shape]
         end
       end
 

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -235,7 +235,7 @@ module Smithy
         def initialize(options = {})
           super
           @members = {}
-          @members_by_wire_name = {}  # Temporary wire-name map. Removed by schema extensions.
+          @members_by_wire_name = {} # Temporary wire-name map. Removed by schema extensions.
         end
 
         # @return [Hash<Symbol, MemberShape>]

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -90,9 +90,6 @@ module Smithy
         def member?: (Symbol?) -> bool
         def member: (Symbol) -> MemberShape?
         def member_by_wire_name: (String) -> [Symbol, MemberShape]?
-
-        private
-        def register_wire_name: (String?, Symbol, MemberShape) -> void
       end
 
       class TimestampShape < Shape

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -89,6 +89,10 @@ module Smithy
         def add_member: (Symbol, MemberShape) -> MemberShape
         def member?: (Symbol?) -> bool
         def member: (Symbol) -> MemberShape?
+        def member_by_wire_name: (String) -> [Symbol, MemberShape]?
+
+        private
+        def register_wire_name: (String?, Symbol, MemberShape) -> void
       end
 
       class TimestampShape < Shape

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -89,7 +89,7 @@ module Smithy
         def add_member: (Symbol, MemberShape) -> MemberShape
         def member?: (Symbol?) -> bool
         def member: (Symbol) -> MemberShape?
-        # Temporary for the phase-1 wire-name map. Removed by schema extensions.
+        # Temporary wire-name map. Removed by schema extensions.
         def member_by_wire_name: (String) -> [Symbol, MemberShape]?
       end
 

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -89,6 +89,7 @@ module Smithy
         def add_member: (Symbol, MemberShape) -> MemberShape
         def member?: (Symbol?) -> bool
         def member: (Symbol) -> MemberShape?
+        # Temporary for the phase-1 wire-name map. Removed by schema extensions.
         def member_by_wire_name: (String) -> [Symbol, MemberShape]?
       end
 

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -457,27 +457,6 @@ module Smithy
             subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'foo'))
             expect(subject.member_by_wire_name('unknown')).to be_nil
           end
-
-          it 'raises when two members share a location name' do
-            subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'shared'))
-            expect do
-              subject.add_member(:bar, MemberShape.new(target: StringShape.new, location_name: 'shared'))
-            end.to raise_error(ArgumentError, /wire name collision/)
-          end
-
-          it 'raises when a jsonName collides with another member location name' do
-            subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'shared'))
-            expect do
-              subject.add_member(
-                :bar,
-                MemberShape.new(
-                  target: StringShape.new,
-                  location_name: 'bar',
-                  traits: { 'smithy.api#jsonName' => 'shared' }
-                )
-              )
-            end.to raise_error(ArgumentError, /wire name collision/)
-          end
         end
       end
 

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -424,7 +424,6 @@ module Smithy
             expect(subject.member(:foo)).to be_kind_of(MemberShape)
           end
         end
-
       end
 
       describe TimestampShape do

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -425,39 +425,6 @@ module Smithy
           end
         end
 
-        describe '#member_by_wire_name' do
-          it 'resolves a member by its location name' do
-            member_shape = MemberShape.new(target: StringShape.new, location_name: 'foo')
-            subject.add_member(:foo, member_shape)
-            expect(subject.member_by_wire_name('foo')).to eq([:foo, member_shape])
-          end
-
-          it 'also resolves a member by its jsonName when present' do
-            member_shape = MemberShape.new(
-              target: StringShape.new,
-              location_name: 'foo',
-              traits: { 'smithy.api#jsonName' => 'Foo' }
-            )
-            subject.add_member(:foo, member_shape)
-            expect(subject.member_by_wire_name('foo')).to eq([:foo, member_shape])
-            expect(subject.member_by_wire_name('Foo')).to eq([:foo, member_shape])
-          end
-
-          it 'registers a single entry when jsonName equals the location name' do
-            member_shape = MemberShape.new(
-              target: StringShape.new,
-              location_name: 'foo',
-              traits: { 'smithy.api#jsonName' => 'foo' }
-            )
-            subject.add_member(:foo, member_shape)
-            expect(subject.member_by_wire_name('foo')).to eq([:foo, member_shape])
-          end
-
-          it 'returns nil for an unknown wire name' do
-            subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'foo'))
-            expect(subject.member_by_wire_name('unknown')).to be_nil
-          end
-        end
       end
 
       describe TimestampShape do

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -424,6 +424,61 @@ module Smithy
             expect(subject.member(:foo)).to be_kind_of(MemberShape)
           end
         end
+
+        describe '#member_by_wire_name' do
+          it 'resolves a member by its location name' do
+            member_shape = MemberShape.new(target: StringShape.new, location_name: 'foo')
+            subject.add_member(:foo, member_shape)
+            expect(subject.member_by_wire_name('foo')).to eq([:foo, member_shape])
+          end
+
+          it 'also resolves a member by its jsonName when present' do
+            member_shape = MemberShape.new(
+              target: StringShape.new,
+              location_name: 'foo',
+              traits: { 'smithy.api#jsonName' => 'Foo' }
+            )
+            subject.add_member(:foo, member_shape)
+            expect(subject.member_by_wire_name('foo')).to eq([:foo, member_shape])
+            expect(subject.member_by_wire_name('Foo')).to eq([:foo, member_shape])
+          end
+
+          it 'registers a single entry when jsonName equals the location name' do
+            member_shape = MemberShape.new(
+              target: StringShape.new,
+              location_name: 'foo',
+              traits: { 'smithy.api#jsonName' => 'foo' }
+            )
+            subject.add_member(:foo, member_shape)
+            expect(subject.member_by_wire_name('foo')).to eq([:foo, member_shape])
+          end
+
+          it 'returns nil for an unknown wire name' do
+            subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'foo'))
+            expect(subject.member_by_wire_name('unknown')).to be_nil
+          end
+
+          it 'raises when two members share a location name' do
+            subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'shared'))
+            expect do
+              subject.add_member(:bar, MemberShape.new(target: StringShape.new, location_name: 'shared'))
+            end.to raise_error(ArgumentError, /wire name collision/)
+          end
+
+          it 'raises when a jsonName collides with another member location name' do
+            subject.add_member(:foo, MemberShape.new(target: StringShape.new, location_name: 'shared'))
+            expect do
+              subject.add_member(
+                :bar,
+                MemberShape.new(
+                  target: StringShape.new,
+                  location_name: 'bar',
+                  traits: { 'smithy.api#jsonName' => 'shared' }
+                )
+              )
+            end.to raise_error(ArgumentError, /wire name collision/)
+          end
+        end
       end
 
       describe TimestampShape do


### PR DESCRIPTION
## Context
This is the first PR in the current schema-serde stack.

V4 currently walks every declared structure member on each request and response and resolves wire names inline. This PR changes JSON and CBOR structure serde to work from the actual payload or input data instead, using a load-time member lookup to recover the same basic shape V3 had.

Follow-up PR #353 builds on this by replacing the temporary global lookup with protocol-aware schema extensions. I still want early feedback on the traversal change itself, which is why I am splitting the work this way.

## What changed
- `StructureShape` builds a load-time `@members_by_wire_name` index at `add_member`, keyed by each member's `location_name` and `jsonName` when present.
- JSON and CBOR structure build/parse now iterate the input values or payload keys and resolve members through that index instead of walking the full member list.
- XML is unchanged in this PR.

## Testing
- `bundle exec rake smithy-schema:spec`
- `bundle exec rake smithy-json:spec`
- `bundle exec rake smithy-cbor:spec`
- `bundle exec rake smithy:spec:unit`
- `bundle exec rake smithy:spec:protocols smithy:rbs:protocols`
- `bundle exec rake smithy-schema:rbs`
- `aws-sdk-ruby-staging` protocol validation green for `awsJson1_0`, `awsJson1_1`, `restJson1`, `awsQuery`, `ec2Query`, and `restXml`

## Notes
- The benchmark motivation for this pass is the wide-structure JSON/CBOR hot path, where resolving only the members that actually appear is materially better than walking the full modeled member list every time.
- PR #353 narrows the naming behavior so `jsonName` is only used when the active protocol actually requires it.

--
Written with AI assistance and reviewed by jterapin.
