### PR TITLE
refactor: use schema extensions for protocol-aware JSON/CBOR naming

### DIFF
--- a/gems/smithy-cbor/lib/smithy-cbor/builder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/builder.rb
@@ -8,7 +8,7 @@ module Smithy
     class Builder
       include Schema::Shapes
 
-      def initialize(options = {})
+      def initialize(_options = {})
         @extension = Schema::Extension
       end
 

--- a/gems/smithy-cbor/lib/smithy-cbor/builder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/builder.rb
@@ -9,7 +9,7 @@ module Smithy
       include Schema::Shapes
 
       def initialize(options = {})
-        @options = options
+        @extension = Schema::Extension
       end
 
       def build(shape, data)
@@ -61,7 +61,7 @@ module Smithy
           member_shape = members[member_name]
           next unless member_shape
 
-          data[member_shape.model_name] = build_shape(member_shape, value)
+          data[@extension.wire_name(member_shape)] = build_shape(member_shape, value)
         end
       end
 
@@ -71,12 +71,12 @@ module Smithy
         data = {}
         if values.is_a?(Schema::Union)
           _name, member_shape = shape.target.member_by_type(values.class)
-          data[member_shape.model_name] = build_shape(member_shape, values.value)
+          data[@extension.wire_name(member_shape)] = build_shape(member_shape, values.value)
         else
           key, value = values.first
           if shape.target.member?(key)
             member_shape = shape.target.member(key)
-            data[member_shape.model_name] = build_shape(member_shape, value)
+            data[@extension.wire_name(member_shape)] = build_shape(member_shape, value)
           end
         end
         data

--- a/gems/smithy-cbor/lib/smithy-cbor/builder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/builder.rb
@@ -61,7 +61,7 @@ module Smithy
           member_shape = members[member_name]
           next unless member_shape
 
-          data[member_shape.location_name] = build_shape(member_shape, value)
+          data[member_shape.model_name] = build_shape(member_shape, value)
         end
       end
 
@@ -71,12 +71,12 @@ module Smithy
         data = {}
         if values.is_a?(Schema::Union)
           _name, member_shape = shape.target.member_by_type(values.class)
-          data[member_shape.location_name] = build_shape(member_shape, values.value)
+          data[member_shape.model_name] = build_shape(member_shape, values.value)
         else
           key, value = values.first
           if shape.target.member?(key)
             member_shape = shape.target.member(key)
-            data[member_shape.location_name] = build_shape(member_shape, value)
+            data[member_shape.model_name] = build_shape(member_shape, value)
           end
         end
         data

--- a/gems/smithy-cbor/lib/smithy-cbor/builder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/builder.rb
@@ -9,7 +9,7 @@ module Smithy
       include Schema::Shapes
 
       def initialize(_options = {})
-        @extension = Schema::Extension
+        @extension = Smithy::Schema::Extension
       end
 
       def build(shape, data)

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -86,7 +86,7 @@ module Smithy
       end
 
       def sparse?(shape)
-        shape.traits.key?(:sparse)
+        @extension.sparse?(shape)
       end
     end
   end

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -70,7 +70,7 @@ module Smithy
       def union(shape, values, result = nil) # rubocop:disable Metrics/AbcSize
         index = @extension.member_index(shape.target)
         values.each do |wire_name, value|
-          next if wire_name == '__type' || value.nil?
+          next if value.nil?
 
           entry = index[wire_name]
           next unless entry

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -57,19 +57,23 @@ module Smithy
         values.each do |wire_name, value|
           next if value.nil?
 
-          member_name, member_shape = shape.target.member_by_wire_name(wire_name)
-          next unless member_shape
+          entry = Schema::Extension.member_index(shape.target)[wire_name]
+          next unless entry
 
+          member_name, member_shape = entry
           result[member_name] = parse_shape(member_shape, value)
         end
         result
       end
 
       def union(shape, values, result = nil) # rubocop:disable Metrics/AbcSize
-        shape.target.members.each do |member_name, member_shape|
-          value = values[member_shape.location_name]
-          next if value.nil?
+        values.each do |wire_name, value|
+          next if wire_name == '__type' || value.nil?
 
+          entry = Schema::Extension.member_index(shape.target)[wire_name]
+          next unless entry
+
+          member_name, member_shape = entry
           result = shape.target.member_type(member_name) if result.nil?
           return result.new(member_name => parse_shape(member_shape, value))
         end
@@ -80,7 +84,7 @@ module Smithy
       end
 
       def sparse?(shape)
-        shape.traits.key?('smithy.api#sparse')
+        shape.traits.key?(:sparse)
       end
     end
   end

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -8,7 +8,7 @@ module Smithy
     class Parser
       include Schema::Shapes
 
-      def initialize(options = {})
+      def initialize(_options = {})
         @extension = Schema::Extension
       end
 

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -9,7 +9,7 @@ module Smithy
       include Schema::Shapes
 
       def initialize(options = {})
-        @options = options
+        @extension = Schema::Extension
       end
 
       def parse(shape, bytes, result = nil)
@@ -54,10 +54,11 @@ module Smithy
 
       def structure(shape, values, result = nil)
         result = shape.target.type.new if result.nil?
+        index = @extension.member_index(shape.target)
         values.each do |wire_name, value|
           next if value.nil?
 
-          entry = Schema::Extension.member_index(shape.target)[wire_name]
+          entry = index[wire_name]
           next unless entry
 
           member_name, member_shape = entry
@@ -67,10 +68,11 @@ module Smithy
       end
 
       def union(shape, values, result = nil) # rubocop:disable Metrics/AbcSize
+        index = @extension.member_index(shape.target)
         values.each do |wire_name, value|
           next if wire_name == '__type' || value.nil?
 
-          entry = Schema::Extension.member_index(shape.target)[wire_name]
+          entry = index[wire_name]
           next unless entry
 
           member_name, member_shape = entry

--- a/gems/smithy-cbor/lib/smithy-cbor/parser.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/parser.rb
@@ -9,7 +9,7 @@ module Smithy
       include Schema::Shapes
 
       def initialize(_options = {})
-        @extension = Schema::Extension
+        @extension = Smithy::Schema::Extension
       end
 
       def parse(shape, bytes, result = nil)

--- a/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
@@ -88,6 +88,19 @@ module Smithy
           expect(subject.parse(structure_shape, bytes).to_h).to eq(union: { string: 'string' })
         end
 
+        it 'parses unions through the cached member index' do
+          union_shape = structure_shape.member(:union).target
+          string_member = union_shape.member(:string)
+          allow(Schema::Extension).to receive(:member_index).and_call_original
+          allow(Schema::Extension).to receive(:member_index).with(union_shape).and_return(
+            'wireName' => [:string, string_member]
+          )
+
+          data = { 'union' => { 'wireName' => 'string' } }
+          bytes = Cbor.encode(data)
+          expect(subject.parse(structure_shape, bytes).to_h).to eq(union: { string: 'string' })
+        end
+
         it 'parses unit members' do
           data = { 'union' => { 'unit' => {} } }
           bytes = Cbor.encode(data)

--- a/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/parser_spec.rb
@@ -88,19 +88,6 @@ module Smithy
           expect(subject.parse(structure_shape, bytes).to_h).to eq(union: { string: 'string' })
         end
 
-        it 'parses unions through the cached member index' do
-          union_shape = structure_shape.member(:union).target
-          string_member = union_shape.member(:string)
-          allow(Schema::Extension).to receive(:member_index).and_call_original
-          allow(Schema::Extension).to receive(:member_index).with(union_shape).and_return(
-            'wireName' => [:string, string_member]
-          )
-
-          data = { 'union' => { 'wireName' => 'string' } }
-          bytes = Cbor.encode(data)
-          expect(subject.parse(structure_shape, bytes).to_h).to eq(union: { string: 'string' })
-        end
-
         it 'parses unit members' do
           data = { 'union' => { 'unit' => {} } }
           bytes = Cbor.encode(data)

--- a/gems/smithy-client/lib/smithy-client/param_validator.rb
+++ b/gems/smithy-client/lib/smithy-client/param_validator.rb
@@ -27,7 +27,7 @@ module Smithy
 
       private
 
-      # rubocop:disable Metrics
+      # rubocop:disable-next Metrics
       def validate_shape(shape, value, errors, context)
         case shape.target
         when StructureShape then structure(shape, value, errors, context)
@@ -67,7 +67,6 @@ module Smithy
           end
         end
       end
-      # rubocop:enable Metrics
 
       def document(shape, value, errors, context)
         document_types = [Hash, Array, Numeric, String, TrueClass, FalseClass, NilClass]

--- a/gems/smithy-client/lib/smithy-client/protocol_spec_matcher.rb
+++ b/gems/smithy-client/lib/smithy-client/protocol_spec_matcher.rb
@@ -3,7 +3,7 @@
 require 'rspec/expectations'
 
 # Provides an RSpec matcher for protocol specs.
-# rubocop:disable Metrics/BlockLength
+# rubocop:disable-next Metrics/BlockLength
 RSpec::Matchers.define :match_data do |expected|
   match do |actual|
     def match_hash(actual, expected)
@@ -60,4 +60,3 @@ RSpec::Matchers.define :match_data do |expected|
 
   diffable
 end
-# rubocop:enable Metrics/BlockLength

--- a/gems/smithy-client/spec/smithy-client/plugin_list_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugin_list_spec.rb
@@ -10,7 +10,7 @@ module Smithy
         stub_const('Plugin2', Class.new)
       end
 
-      # rubocop:disable Lint/ConstantDefinitionInBlock
+      # rubocop:disable-next Lint/ConstantDefinitionInBlock
       class LazyPlugin
         def self.const_missing(name)
           const = Object.new
@@ -18,7 +18,6 @@ module Smithy
           const
         end
       end
-      # rubocop:enable Lint/ConstantDefinitionInBlock
 
       subject { PluginList.new }
 

--- a/gems/smithy-json/lib/smithy-json.rb
+++ b/gems/smithy-json/lib/smithy-json.rb
@@ -4,6 +4,7 @@ require 'smithy-schema'
 
 require_relative 'smithy-json/builder'
 require_relative 'smithy-json/codec'
+require_relative 'smithy-json/extension'
 require_relative 'smithy-json/parser'
 
 module Smithy

--- a/gems/smithy-json/lib/smithy-json/builder.rb
+++ b/gems/smithy-json/lib/smithy-json/builder.rb
@@ -9,7 +9,7 @@ module Smithy
       include Smithy::Schema::Shapes
 
       def initialize(options = {})
-        @json_name = options[:json_name] || false
+        @extension = options[:json_name] ? Smithy::Json::Extension : Smithy::Schema::Extension
       end
 
       def build(shape, data)
@@ -73,8 +73,7 @@ module Smithy
           member_shape = members[member_name]
           next unless member_shape
 
-          wire_name = @json_name ? Smithy::Json::Extension.wire_name(member_shape) : member_shape.model_name
-          data[wire_name] = build_shape(member_shape, value)
+          data[@extension.wire_name(member_shape)] = build_shape(member_shape, value)
         end
       end
 
@@ -95,14 +94,12 @@ module Smithy
         data = {}
         if values.is_a?(Schema::Union)
           _name, member_shape = shape.target.member_by_type(values.class)
-          wire_name = @json_name ? Smithy::Json::Extension.wire_name(member_shape) : member_shape.model_name
-          data[wire_name] = build_shape(member_shape, values.value)
+          data[@extension.wire_name(member_shape)] = build_shape(member_shape, values.value)
         else
           key, value = values.first
           if shape.target.member?(key)
             member_shape = shape.target.member(key)
-            wire_name = @json_name ? Smithy::Json::Extension.wire_name(member_shape) : member_shape.model_name
-            data[wire_name] = build_shape(member_shape, value)
+            data[@extension.wire_name(member_shape)] = build_shape(member_shape, value)
           end
         end
         data

--- a/gems/smithy-json/lib/smithy-json/builder.rb
+++ b/gems/smithy-json/lib/smithy-json/builder.rb
@@ -73,7 +73,8 @@ module Smithy
           member_shape = members[member_name]
           next unless member_shape
 
-          data[location_name(member_shape)] = build_shape(member_shape, value)
+          wire_name = @json_name ? Smithy::Json::Extension.wire_name(member_shape) : member_shape.model_name
+          data[wire_name] = build_shape(member_shape, value)
         end
       end
 
@@ -94,21 +95,17 @@ module Smithy
         data = {}
         if values.is_a?(Schema::Union)
           _name, member_shape = shape.target.member_by_type(values.class)
-          data[location_name(member_shape)] = build_shape(member_shape, values.value)
+          wire_name = @json_name ? Smithy::Json::Extension.wire_name(member_shape) : member_shape.model_name
+          data[wire_name] = build_shape(member_shape, values.value)
         else
           key, value = values.first
           if shape.target.member?(key)
             member_shape = shape.target.member(key)
-            data[location_name(member_shape)] = build_shape(member_shape, value)
+            wire_name = @json_name ? Smithy::Json::Extension.wire_name(member_shape) : member_shape.model_name
+            data[wire_name] = build_shape(member_shape, value)
           end
         end
         data
-      end
-
-      def location_name(member)
-        return member.location_name unless @json_name
-
-        member.traits['smithy.api#jsonName'] || member.location_name
       end
     end
   end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -5,12 +5,12 @@ module Smithy
     # @api private
     module Extension
       class << self
-        # wire (jsonName or model_name) => [member_name, member_shape]
+        # JSON wire name => [ruby_member_name, member_shape]
         def member_index(shape)
           shape[:json_index] ||= build_member_index(shape)
         end
 
-        # per-member forward wire name (jsonName or model_name)
+        # Resolves the JSON wire name for a member.
         def wire_name(member)
           member.traits[:json_name] || member.model_name
         end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -22,15 +22,30 @@ module Smithy
         # - resolved JSON wire name
         # - to [ruby_member_name, member_shape]
         def member_index(shape)
-          Smithy::Schema::Extension.member_index(shape, json_name: true)
+          shape[:json_index] ||= build_member_index(shape)
         end
 
         # Returns the resolved JSON wire name for the member, cached as
         # +member[:json_name]+ and preferring the Smithy @jsonName trait.
         def wire_name(member)
-          Smithy::Schema::Extension.wire_name(member, json_name: true)
+          cached = member[:json_name]
+          return cached unless cached.nil?
+
+          member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
         end
 
+        private
+
+        def build_member_index(shape)
+          index = {}
+          shape.members.each do |name, member|
+            wire_name = wire_name(member)
+            next unless wire_name
+
+            index[wire_name] = [name, member]
+          end
+          index.freeze
+        end
       end
     end
   end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -2,7 +2,8 @@
 
 module Smithy
   module Json
-    # Lookup helpers for JSON serde using the Smithy @jsonName trait.
+    # Lookup helpers for JSON serde using Smithy traits that affect JSON
+    # wire names.
     # @api private
     module Extension
       class << self
@@ -13,7 +14,14 @@ module Smithy
 
         # Returns the JSON wire name, preferring the Smithy @jsonName trait.
         def wire_name(member)
-          member.traits['smithy.api#jsonName'] || member.name
+          cached = member[:json_name]
+          return cached unless cached.nil?
+
+          member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
+        end
+
+        def sparse?(shape)
+          Smithy::Schema::Extension.sparse?(shape)
         end
 
         private

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -4,15 +4,27 @@ module Smithy
   module Json
     # Lookup helpers for JSON serde using Smithy traits that affect JSON
     # wire names.
+    #
+    # Raw Smithy trait data remains on +member.traits+ with string keys. This
+    # module resolves JSON-specific serde behavior on demand and stores the
+    # resolved values in metadata:
+    # - +member[:json_name]+ caches the resolved JSON wire name for a member
+    # - +shape[:json_index]+ caches the JSON wire-name lookup index for a shape
     # @api private
     module Extension
       class << self
-        # Smithy @jsonName or modeled member name => [ruby_member_name, member_shape]
+        # Returns the JSON member lookup index cached on the shape as
+        # +shape[:json_index]+.
+        #
+        # The index maps:
+        # - resolved JSON wire name
+        # - to [ruby_member_name, member_shape]
         def member_index(shape)
           shape[:json_index] ||= build_member_index(shape)
         end
 
-        # Returns the JSON wire name, preferring the Smithy @jsonName trait.
+        # Returns the resolved JSON wire name for the member, cached as
+        # +member[:json_name]+ and preferring the Smithy @jsonName trait.
         def wire_name(member)
           cached = member[:json_name]
           return cached unless cached.nil?
@@ -20,6 +32,7 @@ module Smithy
           member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
         end
 
+        # Delegates generic sparse handling to the schema extension.
         def sparse?(shape)
           Smithy::Schema::Extension.sparse?(shape)
         end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -12,6 +12,8 @@ module Smithy
     # - +shape[:json_index]+ caches the JSON wire-name lookup index for a shape
     # @api private
     module Extension
+      extend Smithy::Schema::ExtensionHelpers
+
       class << self
         # Returns the JSON member lookup index cached on the shape as
         # +shape[:json_index]+.
@@ -29,10 +31,6 @@ module Smithy
           Smithy::Schema::Extension.wire_name(member, json_name: true)
         end
 
-        # Delegates generic sparse handling to the schema extension.
-        def sparse?(shape)
-          Smithy::Schema::Extension.sparse?(shape)
-        end
       end
     end
   end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -20,33 +20,18 @@ module Smithy
         # - resolved JSON wire name
         # - to [ruby_member_name, member_shape]
         def member_index(shape)
-          shape[:json_index] ||= build_member_index(shape)
+          Smithy::Schema::Extension.member_index(shape, json_name: true)
         end
 
         # Returns the resolved JSON wire name for the member, cached as
         # +member[:json_name]+ and preferring the Smithy @jsonName trait.
         def wire_name(member)
-          cached = member[:json_name]
-          return cached unless cached.nil?
-
-          member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
+          Smithy::Schema::Extension.wire_name(member, json_name: true)
         end
 
         # Delegates generic sparse handling to the schema extension.
         def sparse?(shape)
           Smithy::Schema::Extension.sparse?(shape)
-        end
-
-        private
-
-        def build_member_index(shape)
-          index = {}
-          shape.members.each do |name, member|
-            next unless member.name
-
-            index[wire_name(member)] = [name, member]
-          end
-          index.freeze
         end
       end
     end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -2,15 +2,16 @@
 
 module Smithy
   module Json
+    # Lookup helpers for JSON serde using the Smithy @jsonName trait.
     # @api private
     module Extension
       class << self
-        # JSON wire name => [ruby_member_name, member_shape]
+        # Smithy @jsonName or modeled member name => [ruby_member_name, member_shape]
         def member_index(shape)
           shape[:json_index] ||= build_member_index(shape)
         end
 
-        # Resolves the JSON wire name for a member.
+        # Returns the JSON wire name, preferring the Smithy @jsonName trait.
         def wire_name(member)
           member.traits[:json_name] || member.model_name
         end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Json
+    # @api private
+    module Extension
+      class << self
+        # wire (jsonName or model_name) => [member_name, member_shape]
+        def json_index(shape)
+          shape[:json_index] ||= build_json_index(shape)
+        end
+
+        # per-member forward wire name (jsonName or model_name), cached on member
+        def wire_name(member)
+          member[:json_wire_name] ||= (member.traits[:json_name] || member.model_name).to_s.freeze
+        end
+
+        private
+
+        def build_json_index(shape)
+          index = {}
+          shape.members.each do |name, member|
+            next unless member.model_name
+
+            index[wire_name(member)] = [name, member]
+          end
+          index.freeze
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -6,18 +6,18 @@ module Smithy
     module Extension
       class << self
         # wire (jsonName or model_name) => [member_name, member_shape]
-        def json_index(shape)
-          shape[:json_index] ||= build_json_index(shape)
+        def member_index(shape)
+          shape[:json_index] ||= build_member_index(shape)
         end
 
-        # per-member forward wire name (jsonName or model_name), cached on member
+        # per-member forward wire name (jsonName or model_name)
         def wire_name(member)
-          member[:json_wire_name] ||= (member.traits[:json_name] || member.model_name).to_s.freeze
+          member.traits[:json_name] || member.model_name
         end
 
         private
 
-        def build_json_index(shape)
+        def build_member_index(shape)
           index = {}
           shape.members.each do |name, member|
             next unless member.model_name

--- a/gems/smithy-json/lib/smithy-json/extension.rb
+++ b/gems/smithy-json/lib/smithy-json/extension.rb
@@ -13,7 +13,7 @@ module Smithy
 
         # Returns the JSON wire name, preferring the Smithy @jsonName trait.
         def wire_name(member)
-          member.traits[:json_name] || member.model_name
+          member.traits['smithy.api#jsonName'] || member.name
         end
 
         private
@@ -21,7 +21,7 @@ module Smithy
         def build_member_index(shape)
           index = {}
           shape.members.each do |name, member|
-            next unless member.model_name
+            next unless member.name
 
             index[wire_name(member)] = [name, member]
           end

--- a/gems/smithy-json/lib/smithy-json/parser.rb
+++ b/gems/smithy-json/lib/smithy-json/parser.rb
@@ -98,7 +98,6 @@ module Smithy
         index = @extension.member_index(shape.target)
         values.each do |wire_name, value|
           next if value.nil?
-          next if wire_name == '__type' && !index.key?(wire_name)
 
           entry = index[wire_name]
           next unless entry

--- a/gems/smithy-json/lib/smithy-json/parser.rb
+++ b/gems/smithy-json/lib/smithy-json/parser.rb
@@ -9,7 +9,7 @@ module Smithy
       include Smithy::Schema::Shapes
 
       def initialize(options = {})
-        @json_name = options[:json_name] || false
+        @extension = options[:json_name] ? Smithy::Json::Extension : Smithy::Schema::Extension
       end
 
       def parse(shape, bytes, result = nil)
@@ -68,8 +68,7 @@ module Smithy
         return if values.nil?
 
         result = shape.target.type.new if result.nil?
-        index = @json_name ? Smithy::Json::Extension.json_index(shape.target) :
-                             Smithy::Schema::Extension.member_index(shape.target)
+        index = @extension.member_index(shape.target)
         values.each do |wire_name, value|
           next if value.nil?
 
@@ -96,8 +95,7 @@ module Smithy
       end
 
       def union(shape, values, result = nil) # rubocop:disable Metrics/AbcSize
-        index = @json_name ? Smithy::Json::Extension.json_index(shape.target) :
-                             Smithy::Schema::Extension.member_index(shape.target)
+        index = @extension.member_index(shape.target)
         values.each do |wire_name, value|
           next if value.nil?
           next if wire_name == '__type' && !index.key?(wire_name)

--- a/gems/smithy-json/lib/smithy-json/parser.rb
+++ b/gems/smithy-json/lib/smithy-json/parser.rb
@@ -113,7 +113,7 @@ module Smithy
       end
 
       def sparse?(shape)
-        shape.traits.key?('smithy.api#sparse')
+        @extension.sparse?(shape)
       end
     end
   end

--- a/gems/smithy-json/lib/smithy-json/parser.rb
+++ b/gems/smithy-json/lib/smithy-json/parser.rb
@@ -113,7 +113,7 @@ module Smithy
       end
 
       def sparse?(shape)
-        shape.traits.key?(:sparse)
+        shape.traits.key?('smithy.api#sparse')
       end
     end
   end

--- a/gems/smithy-json/lib/smithy-json/parser.rb
+++ b/gems/smithy-json/lib/smithy-json/parser.rb
@@ -68,12 +68,15 @@ module Smithy
         return if values.nil?
 
         result = shape.target.type.new if result.nil?
+        index = @json_name ? Smithy::Json::Extension.json_index(shape.target) :
+                             Smithy::Schema::Extension.member_index(shape.target)
         values.each do |wire_name, value|
           next if value.nil?
 
-          member_name, member_shape = shape.target.member_by_wire_name(wire_name)
-          next unless member_shape
+          entry = index[wire_name]
+          next unless entry
 
+          member_name, member_shape = entry
           result[member_name] = parse_shape(member_shape, value)
         end
         result
@@ -93,10 +96,16 @@ module Smithy
       end
 
       def union(shape, values, result = nil) # rubocop:disable Metrics/AbcSize
-        shape.target.members.each do |member_name, member_shape|
-          value = values[location_name(member_shape)]
+        index = @json_name ? Smithy::Json::Extension.json_index(shape.target) :
+                             Smithy::Schema::Extension.member_index(shape.target)
+        values.each do |wire_name, value|
           next if value.nil?
+          next if wire_name == '__type' && !index.key?(wire_name)
 
+          entry = index[wire_name]
+          next unless entry
+
+          member_name, member_shape = entry
           result = shape.target.member_type(member_name) if result.nil?
           return result.new(member_name => parse_shape(member_shape, value))
         end
@@ -106,14 +115,8 @@ module Smithy
         shape.target.member_type(:unknown).new(unknown: { key => value })
       end
 
-      def location_name(member)
-        return member.location_name unless @json_name
-
-        member.traits['smithy.api#jsonName'] || member.location_name
-      end
-
       def sparse?(shape)
-        shape.traits.key?('smithy.api#sparse')
+        shape.traits.key?(:sparse)
       end
     end
   end

--- a/gems/smithy-json/spec/smithy-json/extension_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/extension_spec.rb
@@ -5,20 +5,23 @@ require_relative '../spec_helper'
 module Smithy
   module Json
     describe Extension do
-      describe '.member_index' do
-        let(:shape) { Schema::Shapes::StructureShape.new }
-        let(:plain_member) do
-          Schema::Shapes::MemberShape.new(target: Schema::Shapes::StringShape.new, model_name: 'plainName')
-        end
-        let(:json_named_member) do
-          Schema::Shapes::MemberShape.new(
-            target: Schema::Shapes::StringShape.new,
-            model_name: 'modelName',
-            traits: { json_name: 'wireName' }
-          )
-        end
+      let(:json_named_member) do
+        Schema::Shapes::MemberShape.new(
+          target: Schema::Shapes::StringShape.new,
+          model_name: 'modelName',
+          traits: { json_name: 'wireName' }
+        )
+      end
 
+      let(:plain_member) do
+        Schema::Shapes::MemberShape.new(
+          target: Schema::Shapes::StringShape.new,
+          model_name: 'plainName'
+        )
+      end
+      describe '.member_index' do
         it 'indexes members by jsonName when present' do
+          shape = Schema::Shapes::StructureShape.new
           shape.add_member(:plain_name, plain_member)
           shape.add_member(:json_named, json_named_member)
 
@@ -32,22 +35,11 @@ module Smithy
 
       describe '.wire_name' do
         it 'returns jsonName when present' do
-          member = Schema::Shapes::MemberShape.new(
-            target: Schema::Shapes::StringShape.new,
-            model_name: 'modelName',
-            traits: { json_name: 'wireName' }
-          )
-
-          expect(described_class.wire_name(member)).to eq('wireName')
+          expect(described_class.wire_name(json_named_member)).to eq('wireName')
         end
 
         it 'falls back to the model_name' do
-          member = Schema::Shapes::MemberShape.new(
-            target: Schema::Shapes::StringShape.new,
-            model_name: 'modelName'
-          )
-
-          expect(described_class.wire_name(member)).to eq('modelName')
+          expect(described_class.wire_name(plain_member)).to eq('plainName')
         end
       end
     end

--- a/gems/smithy-json/spec/smithy-json/extension_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/extension_spec.rb
@@ -5,7 +5,7 @@ require_relative '../spec_helper'
 module Smithy
   module Json
     describe Extension do
-      describe '.json_index' do
+      describe '.member_index' do
         let(:shape) { Schema::Shapes::StructureShape.new }
         let(:plain_member) do
           Schema::Shapes::MemberShape.new(target: Schema::Shapes::StringShape.new, model_name: 'plainName')
@@ -22,16 +22,16 @@ module Smithy
           shape.add_member(:plain_name, plain_member)
           shape.add_member(:json_named, json_named_member)
 
-          expect(described_class.json_index(shape)).to eq(
+          expect(described_class.member_index(shape)).to eq(
             'plainName' => [:plain_name, plain_member],
             'wireName' => [:json_named, json_named_member]
           )
-          expect(described_class.json_index(shape)).to be_frozen
+          expect(described_class.member_index(shape)).to be_frozen
         end
       end
 
       describe '.wire_name' do
-        it 'memoizes jsonName on the member metadata' do
+        it 'returns jsonName when present' do
           member = Schema::Shapes::MemberShape.new(
             target: Schema::Shapes::StringShape.new,
             model_name: 'modelName',
@@ -39,7 +39,6 @@ module Smithy
           )
 
           expect(described_class.wire_name(member)).to eq('wireName')
-          expect(described_class.wire_name(member)).to be(described_class.wire_name(member))
         end
 
         it 'falls back to the model_name' do

--- a/gems/smithy-json/spec/smithy-json/extension_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/extension_spec.rb
@@ -8,15 +8,15 @@ module Smithy
       let(:json_named_member) do
         Schema::Shapes::MemberShape.new(
           target: Schema::Shapes::StringShape.new,
-          model_name: 'modelName',
-          traits: { json_name: 'wireName' }
+          name: 'modelName',
+          traits: { 'smithy.api#jsonName' => 'wireName' }
         )
       end
 
       let(:plain_member) do
         Schema::Shapes::MemberShape.new(
           target: Schema::Shapes::StringShape.new,
-          model_name: 'plainName'
+          name: 'plainName'
         )
       end
       describe '.member_index' do
@@ -38,7 +38,7 @@ module Smithy
           expect(described_class.wire_name(json_named_member)).to eq('wireName')
         end
 
-        it 'falls back to the model_name' do
+        it 'falls back to the member name' do
           expect(described_class.wire_name(plain_member)).to eq('plainName')
         end
       end

--- a/gems/smithy-json/spec/smithy-json/extension_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/extension_spec.rb
@@ -19,6 +19,10 @@ module Smithy
           name: 'plainName'
         )
       end
+      let(:sparse_shape) do
+        Schema::Shapes::ListShape.new(traits: { 'smithy.api#sparse' => {} })
+      end
+
       describe '.member_index' do
         it 'indexes members by jsonName when present' do
           shape = Schema::Shapes::StructureShape.new
@@ -30,16 +34,28 @@ module Smithy
             'wireName' => [:json_named, json_named_member]
           )
           expect(described_class.member_index(shape)).to be_frozen
+          expect(plain_member[:json_name]).to eq('plainName')
+          expect(json_named_member[:json_name]).to eq('wireName')
         end
       end
 
       describe '.wire_name' do
         it 'returns jsonName when present' do
           expect(described_class.wire_name(json_named_member)).to eq('wireName')
+          expect(json_named_member[:json_name]).to eq('wireName')
         end
 
         it 'falls back to the member name' do
           expect(described_class.wire_name(plain_member)).to eq('plainName')
+          expect(plain_member[:json_name]).to eq('plainName')
+        end
+      end
+
+      describe '.sparse?' do
+        it 'delegates to the generic schema extension' do
+          expect(Smithy::Schema::Extension).to receive(:sparse?).with(sparse_shape).and_return(true)
+
+          expect(described_class.sparse?(sparse_shape)).to be(true)
         end
       end
     end

--- a/gems/smithy-json/spec/smithy-json/extension_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/extension_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+module Smithy
+  module Json
+    describe Extension do
+      describe '.json_index' do
+        let(:shape) { Schema::Shapes::StructureShape.new }
+        let(:plain_member) do
+          Schema::Shapes::MemberShape.new(target: Schema::Shapes::StringShape.new, model_name: 'plainName')
+        end
+        let(:json_named_member) do
+          Schema::Shapes::MemberShape.new(
+            target: Schema::Shapes::StringShape.new,
+            model_name: 'modelName',
+            traits: { json_name: 'wireName' }
+          )
+        end
+
+        it 'indexes members by jsonName when present' do
+          shape.add_member(:plain_name, plain_member)
+          shape.add_member(:json_named, json_named_member)
+
+          expect(described_class.json_index(shape)).to eq(
+            'plainName' => [:plain_name, plain_member],
+            'wireName' => [:json_named, json_named_member]
+          )
+          expect(described_class.json_index(shape)).to be_frozen
+        end
+      end
+
+      describe '.wire_name' do
+        it 'memoizes jsonName on the member metadata' do
+          member = Schema::Shapes::MemberShape.new(
+            target: Schema::Shapes::StringShape.new,
+            model_name: 'modelName',
+            traits: { json_name: 'wireName' }
+          )
+
+          expect(described_class.wire_name(member)).to eq('wireName')
+          expect(described_class.wire_name(member)).to be(described_class.wire_name(member))
+        end
+
+        it 'falls back to the model_name' do
+          member = Schema::Shapes::MemberShape.new(
+            target: Schema::Shapes::StringShape.new,
+            model_name: 'modelName'
+          )
+
+          expect(described_class.wire_name(member)).to eq('modelName')
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-json/spec/smithy-json/extension_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/extension_spec.rb
@@ -52,9 +52,7 @@ module Smithy
       end
 
       describe '.sparse?' do
-        it 'delegates to the generic schema extension' do
-          expect(Smithy::Schema::Extension).to receive(:sparse?).with(sparse_shape).and_return(true)
-
+        it 'uses the shared generic sparse helper' do
           expect(described_class.sparse?(sparse_shape)).to be(true)
         end
       end

--- a/gems/smithy-json/spec/smithy-json/parser_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/parser_spec.rb
@@ -85,7 +85,7 @@ module Smithy
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
 
-        it 'does not resolve members keyed by jsonName without the json_name option' do
+        it 'ignores jsonName when json_name mode is disabled' do
           shapes['smithy.ruby.tests#Structure']['members']['string'] = {
             'target' => 'smithy.api#String',
             'traits' => { 'smithy.api#jsonName' => 'NewString' }

--- a/gems/smithy-json/spec/smithy-json/parser_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/parser_spec.rb
@@ -85,14 +85,14 @@ module Smithy
           expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
         end
 
-        it 'resolves members keyed by jsonName even without the json_name option' do
+        it 'does not resolve members keyed by jsonName without the json_name option' do
           shapes['smithy.ruby.tests#Structure']['members']['string'] = {
             'target' => 'smithy.api#String',
             'traits' => { 'smithy.api#jsonName' => 'NewString' }
           }
           data = { 'NewString' => 'string' }
           bytes = Json.dump(data)
-          expect(subject.parse(structure_shape, bytes).to_h).to eq(string: 'string')
+          expect(subject.parse(structure_shape, bytes).to_h).to eq({})
         end
 
         it 'ignores wire keys that are not members' do

--- a/gems/smithy-schema/lib/smithy-schema.rb
+++ b/gems/smithy-schema/lib/smithy-schema.rb
@@ -5,6 +5,7 @@ require_relative 'smithy-schema/empty_structure'
 require_relative 'smithy-schema/union'
 
 require_relative 'smithy-schema/shapes'
+require_relative 'smithy-schema/extension_helpers'
 require_relative 'smithy-schema/extension'
 require_relative 'smithy-schema/document'
 require_relative 'smithy-schema/type_registry'

--- a/gems/smithy-schema/lib/smithy-schema.rb
+++ b/gems/smithy-schema/lib/smithy-schema.rb
@@ -5,6 +5,7 @@ require_relative 'smithy-schema/empty_structure'
 require_relative 'smithy-schema/union'
 
 require_relative 'smithy-schema/shapes'
+require_relative 'smithy-schema/extension'
 require_relative 'smithy-schema/document'
 require_relative 'smithy-schema/type_registry'
 

--- a/gems/smithy-schema/lib/smithy-schema/document.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document.rb
@@ -48,9 +48,8 @@ module Smithy
       # @param [Hash] opts Formatting options
       # @option opts [Boolean] :timestamp_format Whether to use the `timestampFormat`
       #  trait or ignore it. The `timestampFormat` trait is ignored by default.
-      # @option opts [Module] :extension Lookup extension used to resolve member
-      #   wire names and indexes during serialization. Defaults to
-      #   {Smithy::Schema::Extension}.
+      # @option opts [Boolean] :json_name Whether to use `jsonName` trait
+      #   or just member name. The `jsonName` trait is ignored by default.
       def serialize(type_registry, opts = {})
         validate_document(type_registry)
 
@@ -68,16 +67,14 @@ module Smithy
       # @param [StructureShape, nil] shape shape to use for deserialization.
       #  If provided, this shape takes precedence over the document's discriminator.
       #  The shape must have a type.
-      # @param [Module] extension Lookup extension used to resolve member wire
-      #  names during deserialization. Defaults to {Smithy::Schema::Extension}.
-      def deserialize(type_registry: nil, shape: nil, extension: Smithy::Schema::Extension)
+      def deserialize(type_registry: nil, shape: nil)
         msg = 'either a type registry or a structure shape must be provided to deserialize'
         raise ArgumentError, msg unless type_registry || shape
 
         type_registry.nil? ? validate_shape(shape) : validate_document(type_registry)
 
         shape ||= type_registry[@discriminator]
-        deserializer = DocumentUtils::Deserializer.new(type_registry: type_registry, extension: extension)
+        deserializer = DocumentUtils::Deserializer.new(type_registry: type_registry)
         deserializer.deserialize(@data, shape, shape.type.new)
       end
 

--- a/gems/smithy-schema/lib/smithy-schema/document.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document.rb
@@ -48,8 +48,9 @@ module Smithy
       # @param [Hash] opts Formatting options
       # @option opts [Boolean] :timestamp_format Whether to use the `timestampFormat`
       #  trait or ignore it. The `timestampFormat` trait is ignored by default.
-      # @option opts [Boolean] :json_name Whether to use `jsonName` trait
-      #   or just member name. The `jsonName` trait is ignored by default.
+      # @option opts [Module] :extension Lookup extension used to resolve member
+      #   wire names and indexes during serialization. Defaults to
+      #   {Smithy::Schema::Extension}.
       def serialize(type_registry, opts = {})
         validate_document(type_registry)
 
@@ -67,14 +68,16 @@ module Smithy
       # @param [StructureShape, nil] shape shape to use for deserialization.
       #  If provided, this shape takes precedence over the document's discriminator.
       #  The shape must have a type.
-      def deserialize(type_registry: nil, shape: nil)
+      # @param [Module] extension Lookup extension used to resolve member wire
+      #  names during deserialization. Defaults to {Smithy::Schema::Extension}.
+      def deserialize(type_registry: nil, shape: nil, extension: Smithy::Schema::Extension)
         msg = 'either a type registry or a structure shape must be provided to deserialize'
         raise ArgumentError, msg unless type_registry || shape
 
         type_registry.nil? ? validate_shape(shape) : validate_document(type_registry)
 
         shape ||= type_registry[@discriminator]
-        deserializer = DocumentUtils::Deserializer.new(type_registry: type_registry)
+        deserializer = DocumentUtils::Deserializer.new(type_registry: type_registry, extension: extension)
         deserializer.deserialize(@data, shape, shape.type.new)
       end
 

--- a/gems/smithy-schema/lib/smithy-schema/document.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document.rb
@@ -6,6 +6,7 @@ require 'delegate'
 
 module Smithy
   module Schema
+    # TODO: Implementation needs an update once schema extensions has been settled
     # A Smithy document, representing typed or untyped data from the Smithy data model.
     # The Document class delegates to the underlying data object while providing additional
     # document-specific functionality. The document will represent protocol-agnostic

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -10,6 +10,7 @@ module Smithy
 
         def initialize(options = {})
           @type_registry = options[:type_registry]
+          @extension = options[:extension] || Smithy::Schema::Extension
         end
 
         def deserialize(data, shape, result)
@@ -114,7 +115,7 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          Smithy::Schema::Extension.wire_name(member_shape, json_name: @json_name)
+          @extension.wire_name(member_shape)
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -114,9 +114,9 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          return member_shape.model_name unless @json_name
+          return member_shape.name unless @json_name
 
-          member_shape.traits[:json_name] || member_shape.model_name
+          member_shape.traits['smithy.api#jsonName'] || member_shape.name
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -76,7 +76,7 @@ module Smithy
 
           result = shape.target.type.new if result.nil?
           shape.target.members.each do |member_name, member_shape|
-            value = values[location_name(member_shape)]
+            value = values[wire_name(member_shape)]
             result[member_name] = deserialize_shape(member_shape, value) unless value.nil?
           end
           result
@@ -101,7 +101,7 @@ module Smithy
 
         def union(shape, values, result = nil) # rubocop:disable Metrics/AbcSize
           shape.target.members.each do |member_name, member_shape|
-            value = values[location_name(member_shape)]
+            value = values[wire_name(member_shape)]
             next if value.nil?
 
             result = shape.target.member_type(member_name) if result.nil?
@@ -113,10 +113,10 @@ module Smithy
           shape.target.member_type(:unknown).new(key, value)
         end
 
-        def location_name(member_shape)
-          return member_shape.location_name unless @json_name
+        def wire_name(member_shape)
+          return member_shape.model_name unless @json_name
 
-          member_shape.traits['smithy.api#jsonName'] || member_shape.location_name
+          member_shape.traits[:json_name] || member_shape.model_name
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -116,7 +116,7 @@ module Smithy
         def wire_name(member_shape)
           return member_shape.name unless @json_name
 
-          member_shape.traits['smithy.api#jsonName'] || member_shape.name
+          Smithy::Json::Extension.wire_name(member_shape)
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -10,7 +10,6 @@ module Smithy
 
         def initialize(options = {})
           @type_registry = options[:type_registry]
-          @extension = options[:extension] || Smithy::Schema::Extension
         end
 
         def deserialize(data, shape, result)
@@ -115,7 +114,7 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          @extension.wire_name(member_shape)
+          Smithy::Schema::Extension.wire_name(member_shape)
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -114,9 +114,7 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          return member_shape.name unless @json_name
-
-          Smithy::Json::Extension.wire_name(member_shape)
+          Smithy::Schema::Extension.wire_name(member_shape, json_name: @json_name)
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -146,7 +146,9 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          extension.wire_name(member_shape)
+          return member_shape.name unless @json_name
+
+          member_shape.traits['smithy.api#jsonName'] || member_shape.name
         end
 
         def normalize_timestamp_value(value)
@@ -160,8 +162,9 @@ module Smithy
         def resolve_member_shape(shape, name)
           return shape.target.member(name) if shape.target.member?(name)
 
-          extension.member_index(shape.target)[name]&.last ||
-            Smithy::Schema::Extension.member_index(shape.target)[name]&.last
+          shape.target.members.values.find do |member_shape|
+            member_shape.traits['smithy.api#jsonName'] == name || member_shape.name == name
+          end
         end
 
         def resolve_value(member_name, member_shape, values)
@@ -169,14 +172,6 @@ module Smithy
           return value unless value.nil?
 
           values[member_name] || values[member_shape.name]
-        end
-
-        def extension
-          return Smithy::Schema::Extension unless @json_name
-
-          return Smithy::Json::Extension if defined?(Smithy::Json::Extension)
-
-          raise LoadError, 'smithy-json must be loaded to use Document serialization with json_name: true'
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -14,7 +14,7 @@ module Smithy
         def initialize(options = {})
           @type_registry = options[:type_registry]
           @json = options[:json] || false
-          @json_name = options[:json_name] || false
+          @extension = options[:extension] || Smithy::Schema::Extension
           @timestamp_format = options[:timestamp_format] || false
         end
 
@@ -146,7 +146,7 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          Smithy::Schema::Extension.wire_name(member_shape, json_name: @json_name)
+          @extension.wire_name(member_shape)
         end
 
         def normalize_timestamp_value(value)
@@ -160,19 +160,14 @@ module Smithy
         def resolve_member_shape(shape, name)
           return shape.target.member(name) if shape.target.member?(name)
 
-          if @json_name
-            Smithy::Schema::Extension.member_index(shape.target, json_name: true)[name]&.last ||
-              Smithy::Schema::Extension.member_index(shape.target)[name]&.last
-          else
+          @extension.member_index(shape.target)[name]&.last ||
             Smithy::Schema::Extension.member_index(shape.target)[name]&.last
-          end
         end
 
         def resolve_value(member_name, member_shape, values)
-          if @json_name && (json_name = Smithy::Schema::Extension.wire_name(member_shape, json_name: true))
-            value = values[json_name]
-            return value unless value.nil?
-          end
+          value = values[wire_name(member_shape)]
+          return value unless value.nil?
+
           values[member_name] || values[member_shape.name]
         end
       end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -14,7 +14,7 @@ module Smithy
         def initialize(options = {})
           @type_registry = options[:type_registry]
           @json = options[:json] || false
-          @extension = options[:extension] || Smithy::Schema::Extension
+          @json_name = options[:json_name] || false
           @timestamp_format = options[:timestamp_format] || false
         end
 
@@ -146,7 +146,7 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          @extension.wire_name(member_shape)
+          extension.wire_name(member_shape)
         end
 
         def normalize_timestamp_value(value)
@@ -160,7 +160,7 @@ module Smithy
         def resolve_member_shape(shape, name)
           return shape.target.member(name) if shape.target.member?(name)
 
-          @extension.member_index(shape.target)[name]&.last ||
+          extension.member_index(shape.target)[name]&.last ||
             Smithy::Schema::Extension.member_index(shape.target)[name]&.last
         end
 
@@ -169,6 +169,14 @@ module Smithy
           return value unless value.nil?
 
           values[member_name] || values[member_shape.name]
+        end
+
+        def extension
+          return Smithy::Schema::Extension unless @json_name
+
+          return Smithy::Json::Extension if defined?(Smithy::Json::Extension)
+
+          raise LoadError, 'smithy-json must be loaded to use Document serialization with json_name: true'
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -146,9 +146,9 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          return member_shape.model_name unless @json_name
+          return member_shape.name unless @json_name
 
-          member_shape.traits[:json_name] || member_shape.model_name
+          member_shape.traits['smithy.api#jsonName'] || member_shape.name
         end
 
         def normalize_timestamp_value(value)
@@ -163,16 +163,16 @@ module Smithy
           return shape.target.member(name) if shape.target.member?(name)
 
           shape.target.members.values.find do |member_shape|
-            member_shape.traits[:json_name] == name || member_shape.model_name == name
+            member_shape.traits['smithy.api#jsonName'] == name || member_shape.name == name
           end
         end
 
         def resolve_value(member_name, member_shape, values)
-          if (json_name = member_shape.traits[:json_name])
+          if (json_name = member_shape.traits['smithy.api#jsonName'])
             value = values[json_name]
             return value unless value.nil?
           end
-          values[member_name] || values[member_shape.model_name]
+          values[member_name] || values[member_shape.name]
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -146,9 +146,7 @@ module Smithy
         end
 
         def wire_name(member_shape)
-          return member_shape.name unless @json_name
-
-          Smithy::Json::Extension.wire_name(member_shape)
+          Smithy::Schema::Extension.wire_name(member_shape, json_name: @json_name)
         end
 
         def normalize_timestamp_value(value)
@@ -163,7 +161,7 @@ module Smithy
           return shape.target.member(name) if shape.target.member?(name)
 
           if @json_name
-            Smithy::Json::Extension.member_index(shape.target)[name]&.last ||
+            Smithy::Schema::Extension.member_index(shape.target, json_name: true)[name]&.last ||
               Smithy::Schema::Extension.member_index(shape.target)[name]&.last
           else
             Smithy::Schema::Extension.member_index(shape.target)[name]&.last
@@ -171,7 +169,7 @@ module Smithy
         end
 
         def resolve_value(member_name, member_shape, values)
-          if @json_name && (json_name = Smithy::Json::Extension.wire_name(member_shape))
+          if @json_name && (json_name = Smithy::Schema::Extension.wire_name(member_shape, json_name: true))
             value = values[json_name]
             return value unless value.nil?
           end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -111,7 +111,7 @@ module Smithy
 
           shape.target.members.each_with_object({}) do |(member_name, member_shape), data|
             value = resolve_value(member_name, member_shape, values.to_h)
-            data[location_name(member_shape)] = serialize_shape(member_shape, value) unless value.nil?
+            data[wire_name(member_shape)] = serialize_shape(member_shape, value) unless value.nil?
           end
         end
 
@@ -135,20 +135,20 @@ module Smithy
           data = {}
           if values.is_a?(Union)
             _name, member_shape = shape.target.member_by_type(values.class)
-            data[location_name(member_shape)] = serialize_shape(member_shape, values)
+            data[wire_name(member_shape)] = serialize_shape(member_shape, values)
           else
             key, value = values.first
             if (member_shape = resolve_member_shape(shape, key))
-              data[location_name(member_shape)] = serialize_shape(member_shape, value)
+              data[wire_name(member_shape)] = serialize_shape(member_shape, value)
             end
           end
           data
         end
 
-        def location_name(member_shape)
-          return member_shape.location_name unless @json_name
+        def wire_name(member_shape)
+          return member_shape.model_name unless @json_name
 
-          member_shape.traits['smithy.api#jsonName'] || member_shape.location_name
+          member_shape.traits[:json_name] || member_shape.model_name
         end
 
         def normalize_timestamp_value(value)
@@ -163,16 +163,16 @@ module Smithy
           return shape.target.member(name) if shape.target.member?(name)
 
           shape.target.members.values.find do |member_shape|
-            member_shape.traits['smithy.api#jsonName'] == name || member_shape.location_name == name
+            member_shape.traits[:json_name] == name || member_shape.model_name == name
           end
         end
 
         def resolve_value(member_name, member_shape, values)
-          if (json_name = member_shape.traits['smithy.api#jsonName'])
+          if (json_name = member_shape.traits[:json_name])
             value = values[json_name]
             return value unless value.nil?
           end
-          values[member_name] || values[member_shape.location_name]
+          values[member_name] || values[member_shape.model_name]
         end
       end
     end

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/serializer.rb
@@ -148,7 +148,7 @@ module Smithy
         def wire_name(member_shape)
           return member_shape.name unless @json_name
 
-          member_shape.traits['smithy.api#jsonName'] || member_shape.name
+          Smithy::Json::Extension.wire_name(member_shape)
         end
 
         def normalize_timestamp_value(value)
@@ -162,13 +162,16 @@ module Smithy
         def resolve_member_shape(shape, name)
           return shape.target.member(name) if shape.target.member?(name)
 
-          shape.target.members.values.find do |member_shape|
-            member_shape.traits['smithy.api#jsonName'] == name || member_shape.name == name
+          if @json_name
+            Smithy::Json::Extension.member_index(shape.target)[name]&.last ||
+              Smithy::Schema::Extension.member_index(shape.target)[name]&.last
+          else
+            Smithy::Schema::Extension.member_index(shape.target)[name]&.last
           end
         end
 
         def resolve_value(member_name, member_shape, values)
-          if (json_name = member_shape.traits['smithy.api#jsonName'])
+          if @json_name && (json_name = Smithy::Json::Extension.wire_name(member_shape))
             value = values[json_name]
             return value unless value.nil?
           end

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -10,6 +10,8 @@ module Smithy
     # rebuilding them.
     # @api private
     module Extension
+      extend ExtensionHelpers
+
       class << self
         # Returns the member lookup index cached on the shape as
         # +shape[:member_index]+ or +shape[:json_index]+.
@@ -33,11 +35,6 @@ module Smithy
           return cached unless cached.nil?
 
           member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
-        end
-
-        # Returns whether the shape is sparse.
-        def sparse?(shape)
-          shape.traits.key?('smithy.api#sparse')
         end
 
         private

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -13,7 +13,7 @@ module Smithy
 
         # Returns the modeled member name for generic schema lookup.
         def wire_name(member)
-          member.model_name
+          member.name
         end
 
         private
@@ -21,7 +21,7 @@ module Smithy
         def build_member_index(shape)
           index = {}
           shape.members.each do |name, member|
-            wire_name = member.model_name
+            wire_name = member.name
             next unless wire_name
 
             index[wire_name] = [name, member]

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -2,16 +2,16 @@
 
 module Smithy
   module Schema
-    # Lazily-built, cached lookup tables on shapes. Protocol-agnostic tables live
-    # here; protocol-specific ones live in their codec gems.
+    # Lookup helpers for protocol-agnostic serde using modeled member names.
     # @api private
     module Extension
       class << self
-        # modeled member name => [ruby_member_name, member_shape]
+        # Modeled member name => [ruby_member_name, member_shape]
         def member_index(shape)
           shape[:member_index] ||= build_member_index(shape)
         end
 
+        # Returns the modeled member name for generic schema lookup.
         def wire_name(member)
           member.model_name
         end

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -3,15 +3,25 @@
 module Smithy
   module Schema
     # Lookup helpers for protocol-agnostic serde using modeled member names.
+    #
+    # Raw Smithy trait data remains on +shape.traits+ and +member.traits+ with
+    # string keys. This module only provides generic resolved lookup helpers and
+    # memoizes shape-level indexes in metadata when that meaningfully avoids
+    # rebuilding them.
     # @api private
     module Extension
       class << self
-        # Modeled member name => [ruby_member_name, member_shape]
+        # Returns the generic modeled-member lookup index cached on the shape as
+        # +shape[:member_index]+.
+        #
+        # The index maps:
+        # - modeled member name
+        # - to [ruby_member_name, member_shape]
         def member_index(shape)
           shape[:member_index] ||= build_member_index(shape)
         end
 
-        # Returns the modeled member name for generic schema lookup.
+        # Returns the generic modeled member name for schema lookup.
         def wire_name(member)
           member.name
         end

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Schema
+    # Lazily-built, cached lookup tables on shapes. Protocol-agnostic tables live
+    # here; protocol-specific ones live in their codec gems.
+    # @api private
+    module Extension
+      class << self
+        # wire (model_name) => [member_name, member_shape]
+        def member_index(shape)
+          shape[:member_index] ||= build_member_index(shape)
+        end
+
+        private
+
+        def build_member_index(shape)
+          index = {}
+          shape.members.each do |name, member|
+            wire_name = member.model_name
+            next unless wire_name
+
+            index[wire_name] = [name, member]
+          end
+          index.freeze
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -12,6 +12,10 @@ module Smithy
           shape[:member_index] ||= build_member_index(shape)
         end
 
+        def wire_name(member)
+          member.model_name
+        end
+
         private
 
         def build_member_index(shape)

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -16,6 +16,11 @@ module Smithy
           member.name
         end
 
+        # Returns whether the shape is sparse.
+        def sparse?(shape)
+          shape.traits.key?('smithy.api#sparse')
+        end
+
         private
 
         def build_member_index(shape)

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -11,19 +11,28 @@ module Smithy
     # @api private
     module Extension
       class << self
-        # Returns the generic modeled-member lookup index cached on the shape as
-        # +shape[:member_index]+.
+        # Returns the member lookup index cached on the shape as
+        # +shape[:member_index]+ or +shape[:json_index]+.
         #
         # The index maps:
-        # - modeled member name
+        # - resolved wire name
         # - to [ruby_member_name, member_shape]
-        def member_index(shape)
-          shape[:member_index] ||= build_member_index(shape)
+        def member_index(shape, json_name: false)
+          if json_name
+            shape[:json_index] ||= build_member_index(shape, json_name: true)
+          else
+            shape[:member_index] ||= build_member_index(shape)
+          end
         end
 
-        # Returns the generic modeled member name for schema lookup.
-        def wire_name(member)
-          member.name
+        # Returns the resolved member wire name for schema lookup.
+        def wire_name(member, json_name: false)
+          return member.name unless json_name
+
+          cached = member[:json_name]
+          return cached unless cached.nil?
+
+          member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
         end
 
         # Returns whether the shape is sparse.
@@ -33,10 +42,10 @@ module Smithy
 
         private
 
-        def build_member_index(shape)
+        def build_member_index(shape, json_name: false)
           index = {}
           shape.members.each do |name, member|
-            wire_name = member.name
+            wire_name = wire_name(member, json_name: json_name)
             next unless wire_name
 
             index[wire_name] = [name, member]

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -7,7 +7,7 @@ module Smithy
     # @api private
     module Extension
       class << self
-        # wire (model_name) => [member_name, member_shape]
+        # modeled member name => [ruby_member_name, member_shape]
         def member_index(shape)
           shape[:member_index] ||= build_member_index(shape)
         end

--- a/gems/smithy-schema/lib/smithy-schema/extension.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension.rb
@@ -5,44 +5,35 @@ module Smithy
     # Lookup helpers for protocol-agnostic serde using modeled member names.
     #
     # Raw Smithy trait data remains on +shape.traits+ and +member.traits+ with
-    # string keys. This module only provides generic resolved lookup helpers and
-    # memoizes shape-level indexes in metadata when that meaningfully avoids
-    # rebuilding them.
+    # string keys. This module only provides generic modeled-name lookup
+    # helpers and memoizes shape-level indexes in metadata when that
+    # meaningfully avoids rebuilding them.
     # @api private
     module Extension
       extend ExtensionHelpers
 
       class << self
-        # Returns the member lookup index cached on the shape as
-        # +shape[:member_index]+ or +shape[:json_index]+.
+        # Returns the modeled member lookup index cached on the shape as
+        # +shape[:member_index]+.
         #
         # The index maps:
-        # - resolved wire name
+        # - modeled member name
         # - to [ruby_member_name, member_shape]
-        def member_index(shape, json_name: false)
-          if json_name
-            shape[:json_index] ||= build_member_index(shape, json_name: true)
-          else
-            shape[:member_index] ||= build_member_index(shape)
-          end
+        def member_index(shape)
+          shape[:member_index] ||= build_member_index(shape)
         end
 
-        # Returns the resolved member wire name for schema lookup.
-        def wire_name(member, json_name: false)
-          return member.name unless json_name
-
-          cached = member[:json_name]
-          return cached unless cached.nil?
-
-          member[:json_name] = member.traits['smithy.api#jsonName'] || member.name
+        # Returns the modeled member name for schema lookup.
+        def wire_name(member)
+          member.name
         end
 
         private
 
-        def build_member_index(shape, json_name: false)
+        def build_member_index(shape)
           index = {}
           shape.members.each do |name, member|
-            wire_name = wire_name(member, json_name: json_name)
+            wire_name = wire_name(member)
             next unless wire_name
 
             index[wire_name] = [name, member]

--- a/gems/smithy-schema/lib/smithy-schema/extension_helpers.rb
+++ b/gems/smithy-schema/lib/smithy-schema/extension_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Schema
+    # Shared generic extension helpers used across protocol-specific extensions.
+    # @api private
+    module ExtensionHelpers
+      def sparse?(shape)
+        shape.traits.key?('smithy.api#sparse')
+      end
+    end
+  end
+end

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -43,7 +43,7 @@ module Smithy
       class MemberShape
         def initialize(options = {})
           @target = options[:target]
-          @model_name = options[:model_name] || options[:location_name]
+          @model_name = options[:model_name] || options[:location_name] # Temporary.
           @traits = options[:traits] || {}
           @metadata = {}
         end
@@ -53,7 +53,7 @@ module Smithy
 
         # @return [String, nil]
         attr_accessor :model_name
-        alias location_name model_name
+        alias location_name model_name # Temporary. Will be removed once schema extensions are completed.
 
         # @return [Hash<Symbol | String, Object>]
         attr_accessor :traits

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -21,7 +21,7 @@ module Smithy
         # @return [String] Absolute shape ID from model
         attr_accessor :id
 
-        # @return [String] Shape name
+        # @return [String] Shape name within its Smithy namespace
         attr_accessor :name
 
         # @return [Hash<String, Object>]
@@ -43,7 +43,7 @@ module Smithy
       class MemberShape
         def initialize(options = {})
           @target = options[:target]
-          @model_name = options[:model_name] || options[:location_name] # Temporary.
+          @name = options[:name] || options[:location_name]
           @traits = options[:traits] || {}
           @metadata = {}
         end
@@ -51,11 +51,11 @@ module Smithy
         # @return [Shape]
         attr_accessor :target
 
-        # @return [String, nil]
-        attr_accessor :model_name
-        alias location_name model_name # Temporary. Will be removed once schema extensions are completed.
+        # @return [String, nil] Modeled member name from the Smithy shape.
+        attr_accessor :name
+        alias location_name name # Temporary compatibility for stacked branches and checked-in projections.
 
-        # @return [Hash<Symbol | String, Object>]
+        # @return [Hash<String, Object>]
         attr_accessor :traits
 
         # @return [Object]
@@ -76,14 +76,10 @@ module Smithy
 
         def initialize(options = {})
           super
-          @name = options[:name]
           @version = options[:version]
           @operations = {}
           yield self if block_given?
         end
-
-        # @return [String]
-        attr_accessor :name
 
         # @return [String, nil]
         attr_accessor :version

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -43,7 +43,7 @@ module Smithy
       class MemberShape
         def initialize(options = {})
           @target = options[:target]
-          @location_name = options[:location_name]
+          @model_name = options[:model_name] || options[:location_name]
           @traits = options[:traits] || {}
           @metadata = {}
         end
@@ -52,9 +52,10 @@ module Smithy
         attr_accessor :target
 
         # @return [String, nil]
-        attr_accessor :location_name
+        attr_accessor :model_name
+        alias location_name model_name
 
-        # @return [Hash<String, Object>]
+        # @return [Hash<Symbol | String, Object>]
         attr_accessor :traits
 
         # @return [Object]
@@ -235,7 +236,6 @@ module Smithy
         def initialize(options = {})
           super
           @members = {}
-          @members_by_wire_name = {} # Temporary wire-name map. Removed by schema extensions.
         end
 
         # @return [Hash<Symbol, MemberShape>]
@@ -247,12 +247,6 @@ module Smithy
         # @return [MemberShape]
         def add_member(name, member_shape)
           @members[name] = member_shape
-          # Temporary wire-name map. Removed by schema extensions.
-          @members_by_wire_name[member_shape.location_name] = [name, member_shape]
-          json_name = member_shape.traits['smithy.api#jsonName']
-          if json_name && json_name != member_shape.location_name
-            @members_by_wire_name[json_name] = [name, member_shape]
-          end
           member_shape
         end
 
@@ -266,13 +260,6 @@ module Smithy
         # @return [MemberShape, nil]
         def member(name)
           @members[name]
-        end
-
-        # Temporary wire-name map. Removed by schema extensions.
-        # @param [String] wire_name
-        # @return [[Symbol, MemberShape], nil] +[member_name, member_shape]+ or nil
-        def member_by_wire_name(wire_name)
-          @members_by_wire_name[wire_name]
         end
       end
 

--- a/gems/smithy-schema/sig/smithy-schema/extension.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/extension.rbs
@@ -1,8 +1,8 @@
 module Smithy
   module Schema
     module Extension
-      def self.member_index: (untyped shape, ?json_name: bool) -> Hash[String, [Symbol, Shapes::MemberShape]]
-      def self.wire_name: (Shapes::MemberShape member, ?json_name: bool) -> String?
+      def self.member_index: (untyped shape) -> Hash[String, [Symbol, Shapes::MemberShape]]
+      def self.wire_name: (Shapes::MemberShape member) -> String?
       def self.sparse?: (untyped shape) -> bool
     end
   end

--- a/gems/smithy-schema/sig/smithy-schema/extension.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/extension.rbs
@@ -2,6 +2,7 @@ module Smithy
   module Schema
     module Extension
       def self.member_index: (untyped shape) -> Hash[String, [Symbol, Shapes::MemberShape]]
+      def self.wire_name: (Shapes::MemberShape member) -> String?
     end
   end
 end

--- a/gems/smithy-schema/sig/smithy-schema/extension.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/extension.rbs
@@ -1,8 +1,9 @@
 module Smithy
   module Schema
     module Extension
-      def self.member_index: (untyped shape) -> Hash[String, [Symbol, Shapes::MemberShape]]
-      def self.wire_name: (Shapes::MemberShape member) -> String?
+      def self.member_index: (untyped shape, ?json_name: bool) -> Hash[String, [Symbol, Shapes::MemberShape]]
+      def self.wire_name: (Shapes::MemberShape member, ?json_name: bool) -> String?
+      def self.sparse?: (untyped shape) -> bool
     end
   end
 end

--- a/gems/smithy-schema/sig/smithy-schema/extension.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/extension.rbs
@@ -1,0 +1,7 @@
+module Smithy
+  module Schema
+    module Extension
+      def self.member_index: (untyped shape) -> Hash[String, [Symbol, Shapes::MemberShape]]
+    end
+  end
+end

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -7,7 +7,7 @@ module Smithy
         attr_reader target: Shape
         attr_accessor id: String
         attr_accessor name: String
-        attr_accessor traits: Hash[String, untyped]
+        attr_accessor traits: Hash[Symbol | String, untyped]
         def []: (Symbol) -> Object
         def []=: (Symbol, Object) -> void
       end
@@ -16,8 +16,9 @@ module Smithy
         def initialize: (?Hash[Symbol, untyped]) -> void
 
         attr_accessor target: Shape
-        attr_accessor location_name: String?
-        attr_accessor traits: Hash[String, untyped]
+        attr_accessor model_name: String?
+        alias location_name model_name
+        attr_accessor traits: Hash[Symbol | String, untyped]
         def []: (Symbol) -> Object
         def []=: (Symbol, Object) -> void
       end
@@ -89,8 +90,6 @@ module Smithy
         def add_member: (Symbol, MemberShape) -> MemberShape
         def member?: (Symbol?) -> bool
         def member: (Symbol) -> MemberShape?
-        # Temporary wire-name map. Removed by schema extensions.
-        def member_by_wire_name: (String) -> [Symbol, MemberShape]?
       end
 
       class TimestampShape < Shape

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -7,7 +7,7 @@ module Smithy
         attr_reader target: Shape
         attr_accessor id: String
         attr_accessor name: String
-        attr_accessor traits: Hash[Symbol | String, untyped]
+        attr_accessor traits: Hash[String, untyped]
         def []: (Symbol) -> Object
         def []=: (Symbol, Object) -> void
       end
@@ -16,16 +16,15 @@ module Smithy
         def initialize: (?Hash[Symbol, untyped]) -> void
 
         attr_accessor target: Shape
-        attr_accessor model_name: String?
-        alias location_name model_name # Temporary. Will be removed once schema extensions are completed.
-        attr_accessor traits: Hash[Symbol | String, untyped]
+        attr_accessor name: String?
+        alias location_name name
+        attr_accessor traits: Hash[String, untyped]
         def []: (Symbol) -> Object
         def []=: (Symbol, Object) -> void
       end
 
       class ServiceShape < Shape
         include Enumerable[Shapes::OperationShape]
-        attr_accessor name: String
         attr_accessor version: String?
         attr_accessor operations: Hash[Symbol, Shapes::OperationShape]
         def add_operation: (Symbol, Shapes::OperationShape) -> void

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -17,7 +17,7 @@ module Smithy
 
         attr_accessor target: Shape
         attr_accessor model_name: String?
-        alias location_name model_name
+        alias location_name model_name # Temporary. Will be removed once schema extensions are completed.
         attr_accessor traits: Hash[Symbol | String, untyped]
         def []: (Symbol) -> Object
         def []=: (Symbol, Object) -> void

--- a/gems/smithy-schema/spec/smithy-schema/document_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/document_spec.rb
@@ -96,13 +96,13 @@ module Smithy
             )
         end
 
-        it 'applies jsonName trait to serialized data when using the JSON extension' do
+        it 'applies jsonName trait to serialized data when configured' do
           shapes['smithy.ruby.tests#Structure']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'A' }
           shapes['smithy.ruby.tests#Union']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'B' }
 
           typed_structure = structure_shape.type.new(string: 'hello', union: { string: 'world' })
           document = Document.create(typed_structure, type_registry)
-          expect(document.serialize(type_registry, extension: Smithy::Json::Extension)).to eq(
+          expect(document.serialize(type_registry, json_name: true)).to eq(
             '__type' => 'smithy.ruby.tests#Structure',
             'A' => 'hello',
             'union' => { 'B' => 'world' }
@@ -172,28 +172,6 @@ module Smithy
             timestamp: Time.at(1_735_084_800).utc,
             union: { string: 'string' }
           )
-        end
-
-        it 'applies jsonName trait when using the JSON extension' do
-          shapes['smithy.ruby.tests#Structure']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'A' }
-          shapes['smithy.ruby.tests#Union']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'B' }
-
-          document = Document.new(
-            {
-              '__type' => 'smithy.ruby.tests#Structure',
-              'A' => 'hello',
-              'union' => { 'B' => 'world' }
-            },
-            discriminator: structure_shape.id
-          )
-
-          expect(document.deserialize(
-                   type_registry: type_registry,
-                   extension: Smithy::Json::Extension
-                 ).to_h).to eq(
-                   string: 'hello',
-                   union: { string: 'world' }
-                 )
         end
 
         it 'prioritizes provided shape over document discriminator when deserializing' do

--- a/gems/smithy-schema/spec/smithy-schema/document_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/document_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative '../spec_helper'
 require_relative '../support/schema_helper'
+require 'smithy-json'
 
 module Smithy
   module Schema
@@ -95,13 +96,13 @@ module Smithy
             )
         end
 
-        it 'applies jsonName trait to serialized data when configured' do
+        it 'applies jsonName trait to serialized data when using the JSON extension' do
           shapes['smithy.ruby.tests#Structure']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'A' }
           shapes['smithy.ruby.tests#Union']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'B' }
 
           typed_structure = structure_shape.type.new(string: 'hello', union: { string: 'world' })
           document = Document.create(typed_structure, type_registry)
-          expect(document.serialize(type_registry, json_name: true)).to eq(
+          expect(document.serialize(type_registry, extension: Smithy::Json::Extension)).to eq(
             '__type' => 'smithy.ruby.tests#Structure',
             'A' => 'hello',
             'union' => { 'B' => 'world' }
@@ -171,6 +172,28 @@ module Smithy
             timestamp: Time.at(1_735_084_800).utc,
             union: { string: 'string' }
           )
+        end
+
+        it 'applies jsonName trait when using the JSON extension' do
+          shapes['smithy.ruby.tests#Structure']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'A' }
+          shapes['smithy.ruby.tests#Union']['members']['string']['traits'] = { 'smithy.api#jsonName' => 'B' }
+
+          document = Document.new(
+            {
+              '__type' => 'smithy.ruby.tests#Structure',
+              'A' => 'hello',
+              'union' => { 'B' => 'world' }
+            },
+            discriminator: structure_shape.id
+          )
+
+          expect(document.deserialize(
+                   type_registry: type_registry,
+                   extension: Smithy::Json::Extension
+                 ).to_h).to eq(
+                   string: 'hello',
+                   union: { string: 'world' }
+                 )
         end
 
         it 'prioritizes provided shape over document discriminator when deserializing' do

--- a/gems/smithy-schema/spec/smithy-schema/document_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/document_spec.rb
@@ -2,7 +2,6 @@
 
 require_relative '../spec_helper'
 require_relative '../support/schema_helper'
-require 'smithy-json'
 
 module Smithy
   module Schema

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -28,19 +28,6 @@ module Smithy
           expect(described_class.member_index(shape)).to be(described_class.member_index(shape))
         end
 
-        it 'builds a jsonName-aware index when requested' do
-          json_named_member = Shapes::MemberShape.new(
-            target: Shapes::StringShape.new,
-            name: 'wireName',
-            traits: { 'smithy.api#jsonName' => 'jsonWireName' }
-          )
-          shape.add_member(:some_member, json_named_member)
-
-          expect(described_class.member_index(shape, json_name: true)).to eq(
-            'jsonWireName' => [:some_member, json_named_member]
-          )
-          expect(shape[:json_index]).to be(described_class.member_index(shape, json_name: true))
-        end
       end
 
       describe '.wire_name' do
@@ -52,17 +39,6 @@ module Smithy
           )
 
           expect(described_class.wire_name(member)).to eq('wireName')
-        end
-
-        it 'returns the jsonName when requested' do
-          member = Shapes::MemberShape.new(
-            target: Shapes::StringShape.new,
-            name: 'wireName',
-            traits: { 'smithy.api#jsonName' => 'jsonWireName' }
-          )
-
-          expect(described_class.wire_name(member, json_name: true)).to eq('jsonWireName')
-          expect(member[:json_name]).to eq('jsonWireName')
         end
       end
 

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -7,33 +7,25 @@ module Smithy
     describe Extension do
       describe '.member_index' do
         let(:shape) { Shapes::StructureShape.new }
-        let(:first_member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, model_name: 'wireName') }
-        let(:second_member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, model_name: 'wireName') }
+        let(:member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, model_name: 'wireName') }
 
         it 'returns a frozen member index keyed by model_name' do
-          shape.add_member(:first_member, first_member)
+          shape.add_member(:some_member, member)
 
-          expect(described_class.member_index(shape)).to eq('wireName' => [:first_member, first_member])
+          expect(described_class.member_index(shape)).to eq('wireName' => [:some_member, member])
           expect(described_class.member_index(shape)).to be_frozen
         end
 
-        it 'skips members without a model_name' do
+        it 'ignores members that do not have a modeled member name' do
           shape.add_member(:missing_name, Shapes::MemberShape.new(target: Shapes::StringShape.new))
 
           expect(described_class.member_index(shape)).to eq({})
         end
 
         it 'memoizes the index on the shape metadata' do
-          shape.add_member(:first_member, first_member)
+          shape.add_member(:some_member, member)
 
           expect(described_class.member_index(shape)).to be(described_class.member_index(shape))
-        end
-
-        it 'keeps the last member for duplicate wire names' do
-          shape.add_member(:first_member, first_member)
-          shape.add_member(:second_member, second_member)
-
-          expect(described_class.member_index(shape)).to eq('wireName' => [:second_member, second_member])
         end
       end
 

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+module Smithy
+  module Schema
+    describe Extension do
+      describe '.member_index' do
+        let(:shape) { Shapes::StructureShape.new }
+        let(:first_member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, model_name: 'wireName') }
+        let(:second_member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, model_name: 'wireName') }
+
+        it 'returns a frozen member index keyed by model_name' do
+          shape.add_member(:first_member, first_member)
+
+          expect(described_class.member_index(shape)).to eq('wireName' => [:first_member, first_member])
+          expect(described_class.member_index(shape)).to be_frozen
+        end
+
+        it 'skips members without a model_name' do
+          shape.add_member(:missing_name, Shapes::MemberShape.new(target: Shapes::StringShape.new))
+
+          expect(described_class.member_index(shape)).to eq({})
+        end
+
+        it 'memoizes the index on the shape metadata' do
+          shape.add_member(:first_member, first_member)
+
+          expect(described_class.member_index(shape)).to be(described_class.member_index(shape))
+        end
+
+        it 'keeps the last member for duplicate wire names' do
+          shape.add_member(:first_member, first_member)
+          shape.add_member(:second_member, second_member)
+
+          expect(described_class.member_index(shape)).to eq('wireName' => [:second_member, second_member])
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -27,6 +27,20 @@ module Smithy
 
           expect(described_class.member_index(shape)).to be(described_class.member_index(shape))
         end
+
+        it 'builds a jsonName-aware index when requested' do
+          json_named_member = Shapes::MemberShape.new(
+            target: Shapes::StringShape.new,
+            name: 'wireName',
+            traits: { 'smithy.api#jsonName' => 'jsonWireName' }
+          )
+          shape.add_member(:some_member, json_named_member)
+
+          expect(described_class.member_index(shape, json_name: true)).to eq(
+            'jsonWireName' => [:some_member, json_named_member]
+          )
+          expect(shape[:json_index]).to be(described_class.member_index(shape, json_name: true))
+        end
       end
 
       describe '.wire_name' do
@@ -38,6 +52,17 @@ module Smithy
           )
 
           expect(described_class.wire_name(member)).to eq('wireName')
+        end
+
+        it 'returns the jsonName when requested' do
+          member = Shapes::MemberShape.new(
+            target: Shapes::StringShape.new,
+            name: 'wireName',
+            traits: { 'smithy.api#jsonName' => 'jsonWireName' }
+          )
+
+          expect(described_class.wire_name(member, json_name: true)).to eq('jsonWireName')
+          expect(member[:json_name]).to eq('jsonWireName')
         end
       end
 

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -40,6 +40,18 @@ module Smithy
           expect(described_class.wire_name(member)).to eq('wireName')
         end
       end
+
+      describe '.sparse?' do
+        it 'returns true when the sparse trait is present' do
+          shape = Shapes::ListShape.new(traits: { 'smithy.api#sparse' => {} })
+
+          expect(described_class.sparse?(shape)).to be(true)
+        end
+
+        it 'returns false when the sparse trait is absent' do
+          expect(described_class.sparse?(Shapes::ListShape.new)).to be(false)
+        end
+      end
     end
   end
 end

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -36,6 +36,18 @@ module Smithy
           expect(described_class.member_index(shape)).to eq('wireName' => [:second_member, second_member])
         end
       end
+
+      describe '.wire_name' do
+        it 'returns the model name' do
+          member = Shapes::MemberShape.new(
+            target: Shapes::StringShape.new,
+            model_name: 'wireName',
+            traits: { json_name: 'jsonWireName' }
+          )
+
+          expect(described_class.wire_name(member)).to eq('wireName')
+        end
+      end
     end
   end
 end

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -27,7 +27,6 @@ module Smithy
 
           expect(described_class.member_index(shape)).to be(described_class.member_index(shape))
         end
-
       end
 
       describe '.wire_name' do

--- a/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/extension_spec.rb
@@ -7,9 +7,9 @@ module Smithy
     describe Extension do
       describe '.member_index' do
         let(:shape) { Shapes::StructureShape.new }
-        let(:member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, model_name: 'wireName') }
+        let(:member) { Shapes::MemberShape.new(target: Shapes::StringShape.new, name: 'wireName') }
 
-        it 'returns a frozen member index keyed by model_name' do
+        it 'returns a frozen member index keyed by member name' do
           shape.add_member(:some_member, member)
 
           expect(described_class.member_index(shape)).to eq('wireName' => [:some_member, member])
@@ -33,8 +33,8 @@ module Smithy
         it 'returns the model name' do
           member = Shapes::MemberShape.new(
             target: Shapes::StringShape.new,
-            model_name: 'wireName',
-            traits: { json_name: 'jsonWireName' }
+            name: 'wireName',
+            traits: { 'smithy.api#jsonName' => 'jsonWireName' }
           )
 
           expect(described_class.wire_name(member)).to eq('wireName')

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -53,10 +53,6 @@ module Smithy
           expect(subject.target).to be(shape)
         end
 
-        it 'defaults a location name to nil' do
-          expect(subject.model_name).to be_nil
-        end
-
         it 'stores a model name' do
           subject = MemberShape.new(model_name: 'foo')
           expect(subject.model_name).to eq('foo')

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -53,9 +53,9 @@ module Smithy
           expect(subject.target).to be(shape)
         end
 
-        it 'stores a model name' do
-          subject = MemberShape.new(model_name: 'foo')
-          expect(subject.model_name).to eq('foo')
+        it 'stores a modeled member name' do
+          subject = MemberShape.new(name: 'foo')
+          expect(subject.name).to eq('foo')
         end
 
         it 'defaults traits to empty hash' do

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -54,11 +54,21 @@ module Smithy
         end
 
         it 'defaults a location name to nil' do
-          expect(subject.location_name).to be_nil
+          expect(subject.model_name).to be_nil
         end
 
-        it 'stores a location name' do
+        it 'stores a model name' do
+          subject = MemberShape.new(model_name: 'foo')
+          expect(subject.model_name).to eq('foo')
+        end
+
+        it 'accepts the legacy location_name option' do
           subject = MemberShape.new(location_name: 'foo')
+          expect(subject.model_name).to eq('foo')
+        end
+
+        it 'aliases location_name to model_name' do
+          subject = MemberShape.new(model_name: 'foo')
           expect(subject.location_name).to eq('foo')
         end
 

--- a/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/shapes_spec.rb
@@ -62,16 +62,6 @@ module Smithy
           expect(subject.model_name).to eq('foo')
         end
 
-        it 'accepts the legacy location_name option' do
-          subject = MemberShape.new(location_name: 'foo')
-          expect(subject.model_name).to eq('foo')
-        end
-
-        it 'aliases location_name to model_name' do
-          subject = MemberShape.new(model_name: 'foo')
-          expect(subject.location_name).to eq('foo')
-        end
-
         it 'defaults traits to empty hash' do
           expect(subject.traits).to eq({})
         end

--- a/gems/smithy/lib/smithy/model/rbs.rb
+++ b/gems/smithy/lib/smithy/model/rbs.rb
@@ -5,7 +5,7 @@ module Smithy
     # @api private
     class RBS
       class << self
-        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable-next Metrics/CyclomaticComplexity
         def type(model, id, shape)
           case shape['type']
           when 'blob', 'string', 'enum' then 'String'
@@ -25,7 +25,6 @@ module Smithy
             'untyped'
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         private
 

--- a/gems/smithy/lib/smithy/templates/client/schema.erb
+++ b/gems/smithy/lib/smithy/templates/client/schema.erb
@@ -14,7 +14,7 @@ module <%= module_name %>
 <% case shape.type -%>
 <% when 'enum', 'intEnum' -%>
 <% shape.members.each do |member| -%>
-    <%= shape.name %>.add_member(:<%= member.name %>, <%= member.initializer %>)
+    <%= shape.name %>.add_member(:<%= member.ruby_name %>, <%= member.initializer %>)
 <% end -%>
 <% when 'list' -%>
     <%= shape.name %>.member = <%= shape.member.initializer %>
@@ -23,7 +23,7 @@ module <%= module_name %>
     <%= shape.name %>.value = <%= shape.value.initializer %>
 <% when 'structure' -%>
 <% shape.members.each do |member| -%>
-    <%= shape.name %>.add_member(:<%= member.name %>, <%= member.initializer %>)
+    <%= shape.name %>.add_member(:<%= member.ruby_name %>, <%= member.initializer %>)
 <% end -%>
 <% if shape.http_payload? -%>
     <%= shape.name %>[:http_payload] = :<%= shape.http_payload %>
@@ -32,7 +32,7 @@ module <%= module_name %>
     <%= shape.name %>.type = <%= shape.type_class %>
 <% when 'union' -%>
 <% shape.members.each do |member| -%>
-    <%= shape.name %>.add_member(:<%= member.name %>, <%= shape.union_type(member) %>, <%= member.initializer %>)
+    <%= shape.name %>.add_member(:<%= member.ruby_name %>, <%= shape.union_type(member) %>, <%= member.initializer %>)
 <% end -%>
     <%= shape.name %>.add_member(:unknown, Types::<%= shape.name %>::Unknown, ::Smithy::Schema::Shapes::MemberShape.new(target: ::Smithy::Schema::Shapes::Prelude::Unit))
     <%= shape.name %>.type = <%= shape.type_class %>

--- a/gems/smithy/lib/smithy/views/client/endpoint_provider_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/endpoint_provider_spec.rb
@@ -67,7 +67,7 @@ module Smithy
             input = find_input(data, operations)
 
             @operation_params = build_operation_params(data, input)
-            @client_params  = build_client_params(data)
+            @client_params = build_client_params(data)
           end
 
           attr_reader :operation_name, :operation_params, :client_params

--- a/gems/smithy/lib/smithy/views/client/request_response_example.rb
+++ b/gems/smithy/lib/smithy/views/client/request_response_example.rb
@@ -49,7 +49,7 @@ module Smithy
           structure(output, '  ', Set.new)
         end
 
-        # rubocop:disable Metrics
+        # rubocop:disable-next Metrics
         def value(target, indent, visited)
           if visited.include?(target)
             shape = Model::Shape.name(target)
@@ -78,7 +78,6 @@ module Smithy
           else raise "unsupported shape type: #{shape['type'].inspect}"
           end
         end
-        # rubocop:enable Metrics
 
         def blob(shape)
           if shape && shape['traits']&.include?('smithy.api#streaming')

--- a/gems/smithy/lib/smithy/views/client/schema.rb
+++ b/gems/smithy/lib/smithy/views/client/schema.rb
@@ -61,6 +61,11 @@ module Smithy
         # including class exposing the unwrapped service hash as +@service+.
         # @api private
         module SchemaHelper
+          SERDE_TRAIT_SYMBOLS = {
+            'smithy.api#jsonName' => :json_name,
+            'smithy.api#sparse' => :sparse
+          }.freeze
+
           # Maps Smithy prelude shape IDs to their generated +Prelude::*+
           # constant names. Prelude shapes are shared built-ins and are never
           # emitted per-service, so they resolve to a fixed constant rather than
@@ -103,6 +108,10 @@ module Smithy
             return "::Smithy::Schema::Shapes::#{PRELUDE_SHAPES_MAP[id]}" if PRELUDE_SHAPES_MAP.key?(id)
 
             (@service.dig('rename', id) || Model::Shape.name(id)).camelize
+          end
+
+          def serde_symbolized_traits(traits)
+            traits.transform_keys { |key| SERDE_TRAIT_SYMBOLS.fetch(key, key) }
           end
         end
 
@@ -217,7 +226,7 @@ module Smithy
 
           def initializer
             options_str = "id: \"#{@id}\", name: \"#{@name}\""
-            options_str += ", traits: #{@traits}" unless @traits.empty?
+            options_str += ", traits: #{serde_symbolized_traits(@traits)}" unless @traits.empty?
             "::Smithy::Schema::Shapes::#{SHAPE_CLASS_MAP[@type]}.new(#{options_str})"
           end
 
@@ -312,7 +321,7 @@ module Smithy
           end
 
           def union_type(member)
-            "#{type_class}::#{member.location_name.camelize}"
+            "#{type_class}::#{member.model_name.camelize}"
           end
         end
 
@@ -324,19 +333,19 @@ module Smithy
             smithy.api#documentation
           ].freeze
 
-          def initialize(service, location_name, member_def)
+          def initialize(service, model_name, member_def)
             @service = service
-            @name = location_name.underscore if location_name
-            @location_name = location_name
+            @name = model_name.underscore if model_name
+            @model_name = model_name
             @target = shape_name_from_id(member_def['target'])
-            @traits = member_def.fetch('traits', {}).except(*OMITTED_TRAITS)
+            @traits = serde_symbolized_traits(member_def.fetch('traits', {}).except(*OMITTED_TRAITS))
           end
 
-          attr_reader :name, :location_name
+          attr_reader :name, :model_name
 
           def initializer
             options_str = "target: #{@target}"
-            options_str += ", location_name: \"#{@location_name}\"" if @location_name
+            options_str += ", model_name: \"#{@model_name}\"" if @model_name
             options_str += ", traits: #{@traits}" unless @traits.empty?
             "::Smithy::Schema::Shapes::MemberShape.new(#{options_str})"
           end

--- a/gems/smithy/lib/smithy/views/client/schema.rb
+++ b/gems/smithy/lib/smithy/views/client/schema.rb
@@ -61,11 +61,6 @@ module Smithy
         # including class exposing the unwrapped service hash as +@service+.
         # @api private
         module SchemaHelper
-          SERDE_TRAIT_SYMBOLS = {
-            'smithy.api#jsonName' => :json_name,
-            'smithy.api#sparse' => :sparse
-          }.freeze
-
           # Maps Smithy prelude shape IDs to their generated +Prelude::*+
           # constant names. Prelude shapes are shared built-ins and are never
           # emitted per-service, so they resolve to a fixed constant rather than
@@ -110,9 +105,6 @@ module Smithy
             (@service.dig('rename', id) || Model::Shape.name(id)).camelize
           end
 
-          def serde_symbolized_traits(traits)
-            traits.transform_keys { |key| SERDE_TRAIT_SYMBOLS.fetch(key, key) }
-          end
         end
 
         # @api private
@@ -226,7 +218,7 @@ module Smithy
 
           def initializer
             options_str = "id: \"#{@id}\", name: \"#{@name}\""
-            options_str += ", traits: #{serde_symbolized_traits(@traits)}" unless @traits.empty?
+            options_str += ", traits: #{@traits}" unless @traits.empty?
             "::Smithy::Schema::Shapes::#{SHAPE_CLASS_MAP[@type]}.new(#{options_str})"
           end
 
@@ -321,7 +313,7 @@ module Smithy
           end
 
           def union_type(member)
-            "#{type_class}::#{member.model_name.camelize}"
+            "#{type_class}::#{member.name.camelize}"
           end
         end
 
@@ -333,19 +325,19 @@ module Smithy
             smithy.api#documentation
           ].freeze
 
-          def initialize(service, model_name, member_def)
+          def initialize(service, member_name, member_def)
             @service = service
-            @name = model_name.underscore if model_name
-            @model_name = model_name
+            @ruby_name = member_name.underscore if member_name
+            @name = member_name
             @target = shape_name_from_id(member_def['target'])
-            @traits = serde_symbolized_traits(member_def.fetch('traits', {}).except(*OMITTED_TRAITS))
+            @traits = member_def.fetch('traits', {}).except(*OMITTED_TRAITS)
           end
 
-          attr_reader :name, :model_name
+          attr_reader :name, :ruby_name
 
           def initializer
             options_str = "target: #{@target}"
-            options_str += ", model_name: \"#{@model_name}\"" if @model_name
+            options_str += ", name: \"#{@name}\"" if @name
             options_str += ", traits: #{@traits}" unless @traits.empty?
             "::Smithy::Schema::Shapes::MemberShape.new(#{options_str})"
           end
@@ -357,7 +349,7 @@ module Smithy
           def http_payload
             return unless http_payload?
 
-            @name
+            @ruby_name
           end
         end
       end

--- a/gems/smithy/lib/smithy/views/client/schema.rb
+++ b/gems/smithy/lib/smithy/views/client/schema.rb
@@ -104,7 +104,6 @@ module Smithy
 
             (@service.dig('rename', id) || Model::Shape.name(id)).camelize
           end
-
         end
 
         # @api private

--- a/gems/smithy/spec/interfaces/schema/serde_traits_spec.rb
+++ b/gems/smithy/spec/interfaces/schema/serde_traits_spec.rb
@@ -47,14 +47,13 @@ describe 'Schema: Serde Traits', rbs_test: true do
     context context do
       include_context context, 'SerdeService', model: model
 
-      it 'emits model_name and symbolized serde traits into runtime shapes' do
+      it 'emits member names and string-keyed serde traits into runtime shapes' do
         member = SerdeService::Schema::SerdeOperationInput.member(:foo_bar)
 
-        expect(member.model_name).to eq('fooBar')
-        expect(member.location_name).to eq('fooBar')
-        expect(member.traits).to eq(json_name: 'foo_bar')
-        expect(SerdeService::Schema::SparseList.traits).to eq(sparse: {})
-        expect(SerdeService::Schema::SparseMap.traits).to eq(sparse: {})
+        expect(member.name).to eq('fooBar')
+        expect(member.traits).to eq('smithy.api#jsonName' => 'foo_bar')
+        expect(SerdeService::Schema::SparseList.traits).to eq('smithy.api#sparse' => {})
+        expect(SerdeService::Schema::SparseMap.traits).to eq('smithy.api#sparse' => {})
       end
     end
   end

--- a/gems/smithy/spec/interfaces/schema/serde_traits_spec.rb
+++ b/gems/smithy/spec/interfaces/schema/serde_traits_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+describe 'Schema: Serde Traits', rbs_test: true do
+  model = {
+    'smithy' => '2.0',
+    'shapes' => {
+      'smithy.ruby.tests#SerdeService' => {
+        'type' => 'service',
+        'version' => '2024-01-01',
+        'operations' => [{ 'target' => 'smithy.ruby.tests#SerdeOperation' }]
+      },
+      'smithy.ruby.tests#SerdeOperation' => {
+        'type' => 'operation',
+        'input' => { 'target' => 'smithy.ruby.tests#SerdeStructure' },
+        'output' => { 'target' => 'smithy.ruby.tests#SerdeStructure' }
+      },
+      'smithy.ruby.tests#SerdeStructure' => {
+        'type' => 'structure',
+        'members' => {
+          'fooBar' => {
+            'target' => 'smithy.api#String',
+            'traits' => { 'smithy.api#jsonName' => 'foo_bar' }
+          },
+          'items' => { 'target' => 'smithy.ruby.tests#SparseList' },
+          'mapping' => { 'target' => 'smithy.ruby.tests#SparseMap' }
+        }
+      },
+      'smithy.ruby.tests#SparseList' => {
+        'type' => 'list',
+        'traits' => { 'smithy.api#sparse' => {} },
+        'member' => { 'target' => 'smithy.api#String' }
+      },
+      'smithy.ruby.tests#SparseMap' => {
+        'type' => 'map',
+        'traits' => { 'smithy.api#sparse' => {} },
+        'key' => { 'target' => 'smithy.api#String' },
+        'value' => { 'target' => 'smithy.api#String' }
+      }
+    }
+  }
+
+  ['generated schema gem', 'generated schema from source code'].each do |context|
+    next if ENV['SMITHY_RUBY_RBS_TEST'] && context != 'generated schema gem'
+
+    context context do
+      include_context context, 'SerdeService', model: model
+
+      it 'emits model_name and symbolized serde traits into runtime shapes' do
+        member = SerdeService::Schema::SerdeOperationInput.member(:foo_bar)
+
+        expect(member.model_name).to eq('fooBar')
+        expect(member.location_name).to eq('fooBar')
+        expect(member.traits).to eq(json_name: 'foo_bar')
+        expect(SerdeService::Schema::SparseList.traits).to eq(sparse: {})
+        expect(SerdeService::Schema::SparseMap.traits).to eq(sparse: {})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
This is the second PR in the stack and should be reviewed on top of #351.

PR #351 moved JSON and CBOR structure serde onto the actual input or payload data, but the follow-up lookup path was still protocol-blind and relied on temporary normalization. This PR moves that lookup behavior behind explicit schema and JSON extension helpers.

## What changed
- Added `Smithy::Schema::Extension` for generic modeled-member lookup and shared trait helpers.
- Added `Smithy::Json::Extension` for `jsonName`-aware lookup used only when JSON serde opts into `json_name` behavior.
- Cached generic member lookup indexes on shapes as `shape[:member_index]`.
- Cached JSON member lookup indexes on shapes as `shape[:json_index]`.
- Cached resolved JSON wire names on members as `member[:json_name]`.
- Restored `MemberShape#name` as the modeled member name and updated generated schema emission accordingly.
- Kept raw Smithy trait data string-keyed rather than symbol-normalizing it so future dynamic-client paths can continue resolving traits directly from model-shaped data.
- Routed document serde `jsonName` handling through the same extension helpers.
- Moved generic `sparse?` handling to `Smithy::Schema::Extension`, with JSON delegating to it.

## Behavior after this change
- JSON with `json_name: true` uses `jsonName`.
- JSON with `json_name: false` uses the modeled member name.
- CBOR uses the modeled member name.
- Union `__type` is only preserved when it is explicitly modeled through `jsonName`.

## Explicit non-goals
- No XML behavior changes in this PR.
- No Query behavior changes in this PR.

## Compatibility note
`MemberShape#initialize` still accepts `location_name:` as a temporary fallback for downstream stacked work and existing generated projections.

## Validation
- `bundle exec rspec gems/smithy-schema/spec gems/smithy-json/spec gems/smithy/spec/interfaces/schema/serde_traits_spec.rb`
- `bundle exec smithy build --debug`

## Performance Summary
### JSON Wins And Regressions
#### Top JSON Wins
- Large AWS JSON `GetItem` response with binary-heavy payload: `16.4%` lower mean latency on Graviton, `10.4%` lower on Intel
- Baseline AWS JSON `PutItem` request: `14.0%` lower mean latency on Intel, `13.4%` lower on Graviton
- Small AWS JSON `PutItem` request with binary payload: `13.4%` lower mean latency on Intel, `10.2%` lower on Graviton
- Baseline AWS JSON `GetItem` response: `12.7%` lower mean latency on Intel, `7.2%` lower on Graviton
- Large AWS JSON `GetItem` response: `11.3%` lower mean latency on Graviton, `8.2%` lower on Intel

Notes:
- The clearest wins are concentrated in AWS JSON `GetItem` / `PutItem` scenarios, especially baseline and binary-heavy payloads.
- Intel shows the broader set of `>=5%` wins, while Graviton still improves on the largest JSON cases.
- Overall, JSON is the strongest-performing protocol family in this benchmark set.

#### Top JSON Regressions
- AWS JSON healthcheck example response: `15.4%` higher mean latency on Intel, `10.4%` higher on Graviton
- AWS JSON healthcheck example request: `7.4%` higher mean latency on Graviton
- Small AWS JSON `GetItem` response payload: `4.6%` higher mean latency on Intel

Notes:
- The healthcheck scenarios are the only clear JSON regressions above the `+5%` threshold.
- Outside those outliers, the remaining JSON regressions are low single-digit and read as near-baseline rather than meaningful movement.

 
### CBOR Wins And Regressions

#### Top CBOR Wins

- Small CBOR `PutItem` request with binary payload: `9.2%` lower mean latency on Intel
- Baseline CBOR `PutItem` request: `8.4%` lower mean latency on Intel, `6.7%` lower on Graviton
- Baseline CBOR `GetItem` response: `6.0%` lower mean latency on Intel, `5.5%` lower on Graviton
- Medium nested CBOR `PutItem` request: `5.4%` lower mean latency on Intel

Notes:
- CBOR shows a handful of real wins, mostly on baseline and `PutItem` request shapes, but the overall effect is modest rather than dramatic.
- Across all CBOR serde cases, mean latency is `1.4%` lower and p99 latency is `2.2%` lower, so most results still cluster close to baseline.

#### Top CBOR Regressions

- No CBOR scenario crosses a `+5%` regression threshold.

--

Written with AI assistance and reviewed by jterapin.
