### PR TITLE
refactor: remove MemberShape location_name alias

### DIFF
--- a/gems/smithy-client/lib/smithy-client/plugins/host_prefix.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/host_prefix.rb
@@ -53,7 +53,7 @@ module Smithy
             name = nil
             input.members.each do |member_name, member_shape|
               next unless member_shape.traits.key?('smithy.api#hostLabel')
-              next unless member_shape.location_name == label
+              next unless member_shape.name == label
 
               name = member_name
             end

--- a/gems/smithy-client/lib/smithy-client/stubbing/empty_stub.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/empty_stub.rb
@@ -56,7 +56,7 @@ module Smithy
         def scalar(shape)
           case shape.target
           when BigDecimalShape then BigDecimal(0)
-          when BlobShape, EnumShape, StringShape then shape.location_name
+          when BlobShape, EnumShape, StringShape then shape.name
           when BooleanShape then false
           when IntegerShape, IntEnumShape then 0
           when FloatShape then 0.0

--- a/gems/smithy-schema/lib/smithy-schema/shapes.rb
+++ b/gems/smithy-schema/lib/smithy-schema/shapes.rb
@@ -43,7 +43,7 @@ module Smithy
       class MemberShape
         def initialize(options = {})
           @target = options[:target]
-          @name = options[:name] || options[:location_name]
+          @name = options[:name]
           @traits = options[:traits] || {}
           @metadata = {}
         end
@@ -53,7 +53,6 @@ module Smithy
 
         # @return [String, nil] Modeled member name from the Smithy shape.
         attr_accessor :name
-        alias location_name name # Temporary compatibility for stacked branches and checked-in projections.
 
         # @return [Hash<String, Object>]
         attr_accessor :traits

--- a/gems/smithy-schema/sig/smithy-schema/shapes.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/shapes.rbs
@@ -17,7 +17,6 @@ module Smithy
 
         attr_accessor target: Shape
         attr_accessor name: String?
-        alias location_name name
         attr_accessor traits: Hash[String, untyped]
         def []: (Symbol) -> Object
         def []=: (Symbol, Object) -> void


### PR DESCRIPTION
## Summary
- remove the temporary `MemberShape#location_name` alias from `Smithy::Schema::Shapes::MemberShape`
- keep modeled member identity on `MemberShape#name`
- update the remaining smithy-client call sites that still depended on `location_name`

## Testing
- `bundle exec rspec gems/smithy-schema/spec/smithy-schema/shapes_spec.rb gems/smithy/spec/interfaces/schema/serde_traits_spec.rb`
- `bundle exec rspec gems/smithy-client/spec/smithy-client/plugins/host_prefix_spec.rb gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb`
- `bundle exec smithy build --debug`

Written with AI assistance and reviewed by jterapin.